### PR TITLE
feat: set C89 standard as default and improve build configuration

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -102,7 +102,7 @@ ninja lib/libcmp.a
 The resulting library `cmplib.a` will be located in the `lib` folder of your build directory.
 
 === Build the AIRSPACE CLI
-To build the xref:programms/README.adoc[CLI utility], run:
+To build the xref:programs/README.adoc[CLI utility], run:
 
 [source,bash]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -9,8 +9,11 @@ endif::[]
 = AIRS Data Compression
 :toc: macro
 
-The AIRS Data Compression is a specialised compression library designed for the AIRS instrument aboard the Ariel space telescope.
-This library implements optimised compression algorithms tailored to the instrument's scientific data processing.
+*AIRS* **P**ort**A**ble **C**ompression **E**ngine (*AIRSPACE*) is a
+specialised compression library designed for the AIRS instrument aboard the
+Ariel space telescope.
+This library implements optimised compression algorithms tailored to the
+instrument's scientific data processing.
 
 [CAUTION]
 .API unstable
@@ -24,11 +27,12 @@ toc::[]
 * Optimised for AIRS scientific data
 * Support for multiple compression configurations
 * Flexible single-pass and multi-pass compression APIs
-* Error handling with detailed error codes
-* Zero dynamic memory allocation
+* Comprehensive error handling with detailed error codes
+* Portable implementation:
+** Library has been written in ANSI C{empty}footnote:[With some GCC extension: like inline]
+** Zero dynamic memory allocation (no internal `malloc()` calls)
 ** Predictable memory usage
-** No internal `malloc()` calls
-
+* Command line utility
 
 == Getting Started
 
@@ -39,30 +43,42 @@ See the xref:INSTALL.adoc[Installation Guide] for detailed setup instructions.
 [source,bash]
 ----
 # Clone the repository
-git clone https://github.com/uviespace/airs-compression.git
+git clone https://github.com/uviespace/airs-compression.git airspace
+cd airspace
 
 # Build using Meson
 meson setup build
 cd build
 ninja
+
+# Results:
+#  - Library: lib/libcmp.a          # Use when linking your applications
+#  - Executable: programs/airspace  # Run to compress/decompress files
 ----
 
 === Examples
-For quick implementation guidance, explore our collection of example code in the link:examples/[`examples`] directory.
+For quick implementation guidance, explore our collection of example code in
+the link:examples/[`examples`] directory.
+
+=== Command Line Interface
+A command-line utility is available for compressing and decompressing AIRS data files.
+See the xref:programs/README.adoc[CLI documentation] for details.
 
 == Documentation
 
 === Usage Documentation
 * xref:INSTALL.adoc[`INSTALL.adoc`] - Installation Guide
 * link:lib/cmp.h[`lib/cmp.h`] - Public Compression API
-* link:examples/[`examples` directory] - Compression Usage Examples
+* link:examples/[`examples/` directory] - Compression Usage Examples
+* xref:programs/README.adoc[`programs/README.adoc`] - CLI utility README
 
 === Technical Details
 * link:lib/cmp_errors.h[`lib/cmp_errors.h`] - Error codes Reference
 * Compression Data Format Documentation - Coming soon
 
 == Contact
-* *Issues*: Please link:https://github.com/uviespace/airs-compression/issues/new[open an issue] for bug reports or feature requests.
+* *Issues*: Please link:https://github.com/uviespace/airs-compression/issues/new[open an issue]
+	for bug reports or feature requests.
 * *Questions*: For general questions, reach out to the maintainer.
 
 === Contact Information
@@ -70,4 +86,5 @@ For quick implementation guidance, explore our collection of example code in the
 * *e-mail*: mailto:dominik.loidolt@univie.ac.at[,Question about AIRS Data Compression]
 
 == License
-This project is licensed under the GNU General Public License v2.0. See the link:LICENSE[] file for complete details.
+This project is licensed under the GNU General Public License v2.0. See the
+link:LICENSE[] file for complete details.

--- a/examples/single_pass_compression.c
+++ b/examples/single_pass_compression.c
@@ -58,7 +58,11 @@ int example_single_pass_compression(void)
 	uint16_t buffer2[SAMPLES_PER_BUFFER] = {0xCA75, 0xCAFE, 0xC0DE};
 
 	/* Create an array of buffer pointers */
-	const uint16_t *src_buffers[] = {buffer1, buffer2};
+	const uint16_t *src_buffers[NUM_BUFFERS];
+
+	src_buffers[0] = buffer1;
+	src_buffers[1] = buffer2;
+
 
 	/*
 	 * Configure Compression Parameters

--- a/lib/common/err_private.h
+++ b/lib/common/err_private.h
@@ -49,7 +49,7 @@
  * @returns non-zero if the code is an error
  */
 
-static inline unsigned int cmp_is_error_int(uint32_t code)
+static __inline unsigned int cmp_is_error_int(uint32_t code)
 {
 	return code > CMP_ERROR(MAX_CODE);
 }

--- a/meson.build
+++ b/meson.build
@@ -1,16 +1,25 @@
-project('ariel_compression', 'c',
-  version: run_command(
-    find_program('scripts/get_library_version.py'), 'lib/cmp.h', check: true)
-      .stdout().strip(),
-  default_options : ['warning_level=3'],
-  meson_version: '>=0.59.0')
+project('AIRSPACE', 'c',
+  meson_version : '>=0.59.0',
+  version : run_command(find_program('python3'),
+    'test/get_library_version.py', 'lib/cmp.h',
+     check : true).stdout().strip(),
+  license : 'GPL-2.0',
+  default_options : [
+    'c_std=c89',
+    'warning_level=3'
+  ]
+)
 
-cc = meson.get_compiler('c')
+fs = import('fs')
+
+compiler = meson.get_compiler('c')
 
 # Built-in options
 use_debug = get_option('debug')
 
 # Compiler flags
+add_project_arguments('-Wno-long-long', language: 'c')
+
 cc_flags = []
 non_testing_flags = []
 if use_debug
@@ -30,7 +39,6 @@ if use_debug
     '-Wundef',
     '-Wvla',
     '-Wdeclaration-after-statement',
-    '-Wstrict-prototypes',
     '-Wwrite-strings',
     '-Wold-style-definition',
     '-Waggregate-return',
@@ -39,20 +47,23 @@ if use_debug
     '-Wdouble-promotion',
     '-Wstrict-overflow=2',
     '-Wformat-truncation',
+    '-Wformat-security',
+    '-Woverflow',
     '-Wdocumentation'
   ]
-  cc_flags += cc.get_supported_arguments(debug_flags)
+  cc_flags += compiler.get_supported_arguments(debug_flags)
 
   # the test runner generator does not generate header files, which is why we
   # do not use these flags for tests
   non_testing_flags = [
     '-Wmissing-declarations',
+    '-Wmissing-prototypes',
     '-Wredundant-decls',
     ]
 endif
 add_project_arguments(cc_flags, language : 'c')
 
-if ['windows', 'cygwin'].contains(host_machine.system()) and cc.get_id() == 'gcc'
+if ['windows', 'cygwin'].contains(host_machine.system()) and compiler.get_id() == 'gcc'
   # by default, MinGW on win32 behaves as if it ignores __attribute__((packed)),
   # you need to add -mno-ms-bitfields to make it work as expected.
   # See: https://wintermade.it/blog/posts/__attribute__packed-on-windows-is-ignored-with-mingw.html
@@ -64,3 +75,7 @@ subdir('lib')
 subdir('programs')
 subdir('examples')
 subdir('test')
+
+summary({
+  'Ruby found': ruby.found(),
+}, section: 'Auto-detected features')

--- a/programs/file.c
+++ b/programs/file.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <assert.h>
 
 #include "file.h"

--- a/programs/log.c
+++ b/programs/log.c
@@ -15,10 +15,9 @@
  */
 
 #include <stdlib.h>
-#include <limits.h>
 
-#include "log.h"
 #include "util.h"
+#include "log.h"
 
 /**
  * Holds a logging configuration

--- a/programs/meson.build
+++ b/programs/meson.build
@@ -8,4 +8,5 @@ airsapcecli = executable('airsapce',
   cli_source,
   include_directories : cmp_inc,
   link_with : cmp_lib,
+  c_args : '-D_POSIX_C_SOURCE=1', # This is needed for some stdio.h function in Linux with ANSI C
   install: true)

--- a/test/get_library_version.py
+++ b/test/get_library_version.py
@@ -14,7 +14,9 @@ def extract_version(header_file):
                 continue
             raise Exception("Unable to find " + part + " version string")
 
-    return version_parts
+    return (
+        f"{version_parts['MAJOR']}.{version_parts['MINOR']}.{version_parts['RELEASE']}"
+    )
 
 
 def main():
@@ -24,8 +26,11 @@ def main():
     parser.add_argument("file", help="path to lib/cmp.h")
     args = parser.parse_args()
     version = extract_version(args.file)
-    print(f"{version['MAJOR']}.{version['MINOR']}.{version['RELEASE']}")
+    print(version)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except:
+        print("unknown")

--- a/test/meson.build
+++ b/test/meson.build
@@ -3,64 +3,68 @@
 # see: https://github.com/google/sanitizers/wiki/SanitizerCommonFlags
 test_env = environment()
 
-test_env.set('ASAN_OPTIONS',
-  'abort_on_error=1',
-  'allocator_may_return_null=1',
-  'allocator_release_to_os_interval_ms=500',
-  'detect_container_overflow=1',
-  'detect_stack_use_after_return=1',
-  'fast_unwind_on_fatal=0','handle_abort=1',
-  'handle_segv=1',
-  'handle_sigill=1',
-  'max_uar_stack_size_log=16',
-  'print_scariness=1',
-  'quarantine_size_mb=10',
-  'strict_memcmp=1',
-  'symbolize=1',
-  'use_sigaltstack=1',
-  'dedup_token_length=3')
+if get_option('b_sanitize').contains('address')
+  test_env.set('ASAN_OPTIONS',
+    'abort_on_error=1',
+    'allocator_may_return_null=1',
+    'allocator_release_to_os_interval_ms=500',
+    'detect_container_overflow=1',
+    'detect_stack_use_after_return=1',
+    'fast_unwind_on_fatal=0','handle_abort=1',
+    'handle_segv=1',
+    'handle_sigill=1',
+    'max_uar_stack_size_log=16',
+    'print_scariness=1',
+    'quarantine_size_mb=10',
+    'strict_memcmp=1',
+    'symbolize=1',
+    'use_sigaltstack=1',
+    'dedup_token_length=3')
 
-if cc.has_argument('-fsanitize=leak')
-  test_env.append('ASAN_OPTIONS', 'detect_leaks=1')
+  if compiler.has_argument('-fsanitize=leak')
+    test_env.append('ASAN_OPTIONS', 'detect_leaks=1')
+  endif
 endif
 
-test_env.set('UBSAN_OPTIONS',
-  'halt_on_error=1',
-  'print_stacktrace=1',
-  'print_summary=1',
-  'symbolize=1',
-  'dedup_token_length=3')
+if get_option('b_sanitize').contains('undefined')
+  test_env.set('UBSAN_OPTIONS',
+    'halt_on_error=1',
+    'print_stacktrace=1',
+    'print_summary=1',
+    'symbolize=1',
+    'dedup_token_length=3')
+endif
 
-test_env.set('MSAN_OPTIONS',
-  'abort_on_error=1',
-  'print_stats=1',
-  'symbolize=1',
-  'dedup_token_length=3')
+if get_option('b_sanitize').contains('memory')
+  test_env.set('MSAN_OPTIONS',
+    'abort_on_error=1',
+    'print_stats=1',
+    'symbolize=1',
+    'dedup_token_length=3')
+endif
 
 
 # setup the Unity Test framework
-unity_dep = dependency('unity', fallback : ['unity', 'unity_dep'])
-# use the test runner generator script
-gen_test_runner = subproject('unity').get_variable('gen_test_runner')
-
-fs = import('fs')
-
-test_src = files(
-  'test_cmp.c',
-  'test_header.c',
-  'test_cmp_errors.c',
-  'test_buildsetup.c')
-
-
 ruby = find_program('ruby', required : false)
 if ruby.found()
-  foreach test_file : test_src
+  unity_dep = dependency('unity', fallback : ['unity', 'unity_dep'])
+
+  # use the test runner generator script
+  gen_test_runner = subproject('unity').get_variable('gen_test_runner')
+
+  unit_test_src = files(
+    'test_cmp.c',
+    'test_header.c',
+    'test_cmp_errors.c',
+    'test_buildsetup.c')
+
+  foreach test_file : unit_test_src
     test_name = fs.name(test_file).split('.')[0]
 
     test_runner = gen_test_runner.process(test_file)
     test_exe = executable(test_name,
       test_file, test_runner, src_common, src_compress,
-      include_directories: [cmp_inc, common_inc, compress_inc],
+      include_directories : [cmp_inc, common_inc, compress_inc],
       c_args : ['-DCMP_MESON_BUILD_ROOT="' + meson.project_build_root() + '/"'],
       dependencies : [unity_dep])
 
@@ -68,6 +72,7 @@ if ruby.found()
       test_exe,
       env : test_env)
   endforeach
+
 else
-   message('ruby not found! Install ruby to run unit tests.')
+   message('Ruby not found. Tests that require Ruby will be disabled.')
 endif

--- a/test/test_buildsetup.c
+++ b/test/test_buildsetup.c
@@ -16,11 +16,10 @@
  * @brief build environment tests
  */
 
-
+#define _ISOC99_SOURCE 1 /* This is needed for snprintf() in Linux with ANSI C */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 #include <unity.h>
 #include <cmp.h>

--- a/test/test_cmp.c
+++ b/test/test_cmp.c
@@ -106,13 +106,16 @@ void test_invalid_compression_initialisation_no_parameters(void)
 void test_initial_data_processing_in_uncompressed_mode(void)
 {
 	struct cmp_context ctx;
-	struct cmp_params par = {.mode = CMP_MODE_UNCOMPRESSED};
+	struct cmp_params par = {0};
 	struct cmp_hdr hdr;
 	const uint16_t data[2] = {0x0001, 0x0203};
 	/* uncompressed data should be in big endian */
 	const uint8_t cmp_data_exp[sizeof(data)] = {0x00, 0x01, 0x02, 0x03};
 	uint8_t *dst[CMP_HDR_SIZE + sizeof(data)];
-	uint32_t cmp_size = cmp_initialise(&ctx, dst, sizeof(dst), &par, NULL, 0);
+	uint32_t cmp_size;
+
+	par.mode = CMP_MODE_UNCOMPRESSED;
+	cmp_size = cmp_initialise(&ctx, dst, sizeof(dst), &par, NULL, 0);
 
 	TEST_ASSERT_FALSE(cmp_is_error(cmp_size));
 


### PR DESCRIPTION
- Update meson.build to set C89 standard as default and include additional compiler flags
- Modify examples/single_pass_compression.c to initialize src_buffers
- Added <sys/types.h> to programs/file.c for compatibility.
- Removed unnecessary <limits.h> include and rearranged header inclusion in programs/log.c.
- Adjust test/test_cmp.c for initial data processing in uncompressed mode
- Added _ISOC99_SOURCE defines to test/test_buildsetup.c for snprintf() compatibility.
- Enhance scripts/get_library_version.py to format the version string
- Refactor test/meson.build to handle different sanitizers and environment settings
- Updated programs/meson.build to define _POSIX_C_SOURCE, this is needed for some stdio.h function in Linux with ANSI C
- correct file paths and update main README