### PR TITLE
Refactor: split public and internal header definitions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -69,11 +69,11 @@ See the xref:programs/README.adoc[CLI documentation] for details.
 * xref:INSTALL.adoc[`INSTALL.adoc`] - Installation Guide
 * link:lib/cmp.h[`lib/cmp.h`] - Public Compression API
 * link:examples/[`examples/` directory] - Compression Usage Examples
-* xref:programs/README.adoc[`programs/README.adoc`] - CLI utility README
+* xref:programs/README.adoc[`programs/README.adoc`] - CLI Utility README
 
 === Technical Details
-* link:lib/cmp_errors.h[`lib/cmp_errors.h`] - Error codes Reference
-* Compression Data Format Documentation - Coming soon
+* link:lib/cmp_errors.h[`lib/cmp_errors.h`] - Error Codes Reference
+* link:lib/cmp_header.h[`lib/cmp_header.h`] - Main Compression Header Definition
 
 == Contact
 * *Issues*: Please link:https://github.com/uviespace/airs-compression/issues/new[open an issue]

--- a/lib/cmp_header.h
+++ b/lib/cmp_header.h
@@ -1,0 +1,64 @@
+/**
+ * @file
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2025
+ *
+ * @copyright GPL-2.0
+ *
+ * @brief Main compression header definitions
+ *
+ * Based on PLATO-UVIE-PL-UM-0001 Issue 0.2
+ */
+
+#ifndef CMP_HEADER_H
+#define CMP_HEADER_H
+
+/*
+ * Maximum values that can be stored in the size fields
+ */
+#define CMP_HDR_MAX_COMPRESSED_SIZE ((1ULL << CMP_HDR_BITS_COMPRESSED_SIZE) - 1)
+#define CMP_HDR_MAX_ORIGINAL_SIZE ((1ULL << CMP_HDR_BITS_ORIGINAL_SIZE) - 1)
+
+
+/*
+ * Bit length of the different header fields
+ */
+#define CMP_HDR_BITS_VERSION (CMP_HDR_BITS_VERSION_FLAG + CMP_HDR_BITS_VERSION_ID)
+#define CMP_HDR_BITS_VERSION_FLAG 1
+#define CMP_HDR_BITS_VERSION_ID 15
+#define CMP_HDR_BITS_COMPRESSED_SIZE 24
+#define CMP_HDR_BITS_ORIGINAL_SIZE 24
+
+#define CMP_HDR_BITS_IDENTIFIER 48
+#define CMP_HDR_BITS_SEQUENCE_NUMBER 8
+
+#define CMP_HDR_BITS_METHOD                                                         \
+	(CMP_HDR_BITS_METHOD_PREPROCESSING + CMP_HDR_BITS_METHOD_CHECKSUM_ENABLED + \
+	 CMP_HDR_BITS_METHOD_ENCODER_TYPE)
+#define CMP_HDR_BITS_METHOD_PREPROCESSING 4
+#define CMP_HDR_BITS_METHOD_CHECKSUM_ENABLED 1
+#define CMP_HDR_BITS_METHOD_ENCODER_TYPE 3
+
+
+/*
+ * Byte offsets of the different header fields
+ */
+#define CMP_HDR_OFFSET_VERSION 0
+#define CMP_HDR_OFFSET_COMPRESSED_SIZE 2
+#define CMP_HDR_OFFSET_ORIGINAL_SIZE 5
+#define CMP_HDR_OFFSET_IDENTIFIER 8
+#define CMP_HDR_OFFSET_SEQUENCE_NUMBER 14
+#define CMP_HDR_OFFSET_METHOD 15
+
+
+/** Size of the compression header in bytes */
+#define CMP_HDR_SIZE                                                                         \
+	((CMP_HDR_BITS_VERSION + CMP_HDR_BITS_COMPRESSED_SIZE + CMP_HDR_BITS_ORIGINAL_SIZE + \
+	  CMP_HDR_BITS_IDENTIFIER + CMP_HDR_BITS_SEQUENCE_NUMBER + CMP_HDR_BITS_METHOD) /    \
+	 8)
+
+
+/** Size of the optional trailing checksum in byes */
+#define CMP_CHECKSUM_SIZE sizeof(uint32_t)
+
+#endif /* CMP_HEADER_H */

--- a/lib/common/header.c
+++ b/lib/common/header.c
@@ -11,7 +11,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "header.h"
+#include "header_private.h"
 #include "err_private.h"
 #include "bitstream_writer.h"
 

--- a/lib/common/header_private.h
+++ b/lib/common/header_private.h
@@ -5,66 +5,30 @@
  *
  * @copyright GPL-2.0
  *
- * @brief Compression header structure and functions
+ * @brief Extended compression header structure and header functions
  */
 
-#ifndef CMP_HEADER_H
-#define CMP_HEADER_H
+#ifndef CMP_HEADER_PRIVATE_H
+#define CMP_HEADER_PRIVATE_H
 
 #include <stdint.h>
 
 #include "bitstream_writer.h"
 #include "../cmp.h"
+#include "../cmp_header.h"
 
-/*
- * Maximum values that can be stored in the size fields
- */
-#define CMP_HDR_MAX_COMPRESSED_SIZE ((1ULL << CMP_HDR_BITS_COMPRESSED_SIZE) - 1)
-#define CMP_HDR_MAX_ORIGINAL_SIZE ((1ULL << CMP_HDR_BITS_ORIGINAL_SIZE) - 1)
 
-/*
- * Bit length of the different header fields
- */
-#define CMP_HDR_BITS_VERSION (CMP_HDR_BITS_VERSION_FLAG + CMP_HDR_BITS_VERSION_ID)
-#define CMP_HDR_BITS_VERSION_FLAG 1
-#define CMP_HDR_BITS_VERSION_ID 15
-#define CMP_HDR_BITS_COMPRESSED_SIZE 24
-#define CMP_HDR_BITS_ORIGINAL_SIZE 24
-
-#define CMP_HDR_BITS_IDENTIFIER 48
-#define CMP_HDR_BITS_SEQUENCE_NUMBER 8
-
-#define CMP_HDR_BITS_METHOD                                                         \
-	(CMP_HDR_BITS_METHOD_PREPROCESSING + CMP_HDR_BITS_METHOD_CHECKSUM_ENABLED + \
-	 CMP_HDR_BITS_METHOD_ENCODER_TYPE)
-#define CMP_HDR_BITS_METHOD_PREPROCESSING 4
-#define CMP_HDR_BITS_METHOD_CHECKSUM_ENABLED 1
-#define CMP_HDR_BITS_METHOD_ENCODER_TYPE 3
-
+/* Bit length of the different extended header fields */
 #define CMP_EXT_HDR_BITS_MODEL_ADAPTATION 8
 #define CMP_EXT_HDR_BITS_ENCODER_PARAM 16
 #define CMP_EXT_HDR_BITS_ENCODER_OUTLIER 24
 
-/*
- * Byte offsets of the different header fields
- */
-#define CMP_HDR_OFFSET_VERSION 0
-#define CMP_HDR_OFFSET_COMPRESSED_SIZE 2
-#define CMP_HDR_OFFSET_ORIGINAL_SIZE 5
-#define CMP_HDR_OFFSET_IDENTIFIER 8
-#define CMP_HDR_OFFSET_SEQUENCE_NUMBER 14
-#define CMP_HDR_OFFSET_METHOD 15
 
 /* Extended header offsets */
 #define CMP_EXT_HDR_OFFSET_MODEL_RATE 16
 #define CMP_EXT_HDR_OFFSET_ENCODER_PARAM 17
 #define CMP_EXT_HDR_OFFSET_OUTLIER_PARAM 19
 
-/** Size of the compression header in bytes TBC */
-#define CMP_HDR_SIZE                                                                         \
-	((CMP_HDR_BITS_VERSION + CMP_HDR_BITS_COMPRESSED_SIZE + CMP_HDR_BITS_ORIGINAL_SIZE + \
-	  CMP_HDR_BITS_IDENTIFIER + CMP_HDR_BITS_SEQUENCE_NUMBER + CMP_HDR_BITS_METHOD) /    \
-	 8)
 
 /** Size of the compression extension headers in bytes TBC */
 #define CMP_EXT_HDR_SIZE                                                       \
@@ -72,15 +36,13 @@
 	  CMP_EXT_HDR_BITS_ENCODER_OUTLIER) /                                  \
 	 8)
 
+
 /** Size of the basic compression plus the extension headers in bytes TBC */
 #define CMP_HDR_MAX_SIZE (CMP_HDR_SIZE + CMP_EXT_HDR_SIZE)
 
 
 /** Seed value used for initializing the checksum computation, arbitrarily chosen*/
 #define CHECKSUM_SEED 419764627
-
-/** Size of the optional checksum in byes */
-#define CMP_CHECKSUM_SIZE sizeof(uint32_t)
 
 
 /**
@@ -151,4 +113,4 @@ uint32_t cmp_hdr_deserialize(const void *src, uint32_t src_size, struct cmp_hdr 
 
 uint32_t cmp_checksum(const uint16_t *data, uint32_t size);
 
-#endif /* CMP_HEADER_H */
+#endif /* CMP_HEADER_PRIVATE_H */

--- a/lib/compress/cmp.c
+++ b/lib/compress/cmp.c
@@ -15,7 +15,7 @@
 #include "../cmp.h"
 #include "../common/err_private.h"
 #include "../common/bitstream_writer.h"
-#include "../common/header.h"
+#include "../common/header_private.h"
 #include "../common/bithacks.h"
 #include "../common/compiler.h"
 

--- a/programs/file.c
+++ b/programs/file.c
@@ -19,7 +19,7 @@
 #include "log.h"
 #include "byteorder.h"
 #include "../lib/cmp.h"
-#include "../lib/common/header.h"
+#include "../lib/cmp_header.h"
 #include "../lib/common/err_private.h"
 
 

--- a/test/test_cmp.c
+++ b/test/test_cmp.c
@@ -16,7 +16,7 @@
 
 #include "../lib/cmp.h"
 #include "../lib/cmp_errors.h"
-#include "../lib/common/header.h"
+#include "../lib/common/header_private.h"
 
 
 static struct cmp_context create_uncompressed_context(void)

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -15,7 +15,7 @@
 
 #include "test_common.h"
 #include "../lib/cmp_errors.h"
-#include "../lib/common/header.h"
+#include "../lib/common/header_private.h"
 
 
 void *cmp_hdr_get_cmp_data(void *header)

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -13,7 +13,7 @@
 #include <unity.h>
 #include "../lib/cmp_errors.h"
 #include "../lib/common/compiler.h"
-#include "../lib/common/bitstream_writer.h"
+#include "../lib/common/header_private.h"
 
 /** uint8_t type with the required compression destination buffer alignment */
 #define DST_ALIGNED_U8 ALIGNED_TYPE(CMP_DST_ALIGNMENT, uint8_t)

--- a/test/test_encoder.c
+++ b/test/test_encoder.c
@@ -14,7 +14,7 @@
 
 #include "../lib/cmp.h"
 #include "../lib/cmp_errors.h"
-#include "../lib/common/header.h"
+#include "../lib/common/header_private.h"
 #include "../lib/common/bitstream_writer.h"
 
 

--- a/test/test_header.c
+++ b/test/test_header.c
@@ -13,7 +13,7 @@
 #include <unity.h>
 #include "test_common.h"
 
-#include "../lib/common/header.h"
+#include "../lib/common/header_private.h"
 #include "../lib/cmp_errors.h"
 #include "../lib/cmp.h"
 #include "../lib/common/bitstream_writer.h"

--- a/test/test_initialisation.c
+++ b/test/test_initialisation.c
@@ -14,7 +14,7 @@
 
 #include "../lib/cmp.h"
 #include "../lib/cmp_errors.h"
-#include "../lib/common/header.h"
+#include "../lib/common/header_private.h"
 
 
 void test_successful_compression_initialisation_without_work_buf(void)

--- a/test/test_preprocessing.c
+++ b/test/test_preprocessing.c
@@ -15,7 +15,7 @@
 #include "test_common.h"
 
 #include "../lib/cmp.h"
-#include "../lib/common/header.h"
+#include "../lib/common/header_private.h"
 #include "../lib/common/compiler.h"
 
 #define TEST_ASSERT_PREPROCCESSING_DATA(expected_output, num_elements, compressed_data) \


### PR DESCRIPTION
Moved shared format constants to a public header (cmp_header.h) and kept serialization internals and extended header definitions in header_private.h to improve encapsulation