### PR TITLE
fix(examples/simple_compression): Improve error handling, simplify and clarify

### DIFF
--- a/examples/simple_compression.c
+++ b/examples/simple_compression.c
@@ -14,8 +14,9 @@
 #include <stdio.h>
 #include <inttypes.h>
 
-#include <cmp.h>
-#include <cmp_errors.h>
+#include "cmp.h"
+#include "cmp_errors.h"
+#include "cmp_header.h"
 
 
 /**
@@ -45,8 +46,8 @@ static int simple_compression(void)
 {
 	/* Define constants for our example */
 	enum {
-		DATA_SAMPLES = 3, /* We comms 3 uint16_t values */
-		DATA_SRC_SIZE = DATA_SAMPLES * sizeof(uint16_t)
+		DATA_SAMPLES_EXAMPLE = 3, /* We comms 3 uint16_t values */
+		DATA_SRC_SIZE_EXAMPLE = DATA_SAMPLES_EXAMPLE * sizeof(uint16_t)
 	};
 
 	struct cmp_params params = { 0 }; /* Parameters for compression configuration */
@@ -76,7 +77,9 @@ static int simple_compression(void)
 	 * In real-world scenarios, you would select an appropriate compression
 	 * mode and the additional parameters.
 	 */
+	params.primary_preprocessing = CMP_PREPROCESS_NONE;
 	params.primary_encoder_type = CMP_ENCODER_UNCOMPRESSED;
+	params.secondary_iterations = 0;
 	/* No additional parameters needed for uncompressed mode */
 
 
@@ -85,14 +88,13 @@ static int simple_compression(void)
 	 * Working buffer is needed for compression algorithm. Not strictly
 	 * necessary for the uncompressed mode, but here is a demo to show how it works.
 	 */
-	work_buf_size = cmp_cal_work_buf_size(&params, DATA_SRC_SIZE);
+	work_buf_size = cmp_cal_work_buf_size(&params, DATA_SRC_SIZE_EXAMPLE);
 	/* NOTE: Most return values of compression functions must be checked
 	 * with cmp_is_error() to check if they were successful.
 	 */
 	if (cmp_is_error(work_buf_size)) {
 		fprintf(stderr, "Error calculating working buffer size: %s. (Error Code: %u)\n",
 			cmp_get_error_message(work_buf_size), cmp_get_error_code(work_buf_size));
-		free(dst);
 		return -1;
 	}
 
@@ -101,7 +103,6 @@ static int simple_compression(void)
 		work_buf = malloc(work_buf_size);
 		if (work_buf == NULL) {
 			fprintf(stderr, "Memory allocation failed for working buffer\n");
-			free(dst);
 			return -1;
 		}
 	}
@@ -115,7 +116,6 @@ static int simple_compression(void)
 	if (cmp_is_error(return_value)) {
 		fprintf(stderr, "Compression initialisation failed: %s. (Error Code: %u)\n",
 			cmp_get_error_message(return_value), cmp_get_error_code(return_value));
-		free(dst);
 		free(work_buf);
 		return -1;
 	}
@@ -126,17 +126,28 @@ static int simple_compression(void)
 	 * We calculate maximum possible compressed size to ensure sufficient
 	 * buffer space for the compressed data.
 	 */
-	dst_capacity = cmp_compress_bound(DATA_SRC_SIZE);
+	dst_capacity = cmp_compress_bound(DATA_SRC_SIZE_EXAMPLE);
 	if (cmp_is_error(dst_capacity)) {
-		fprintf(stderr, "Error calculating destination buffer size: %s. (Error Code: %u)\n",
-			cmp_get_error_message(dst_capacity), cmp_get_error_code(dst_capacity));
-		return -1;
+		if (cmp_get_error_code(dst_capacity) == CMP_ERR_HDR_CMP_SIZE_TOO_LARGE) {
+			dst_capacity = CMP_HDR_MAX_COMPRESSED_SIZE;
+			fprintf(stderr,
+				"Warning: Source data size too large for cmp_compress_bound(). Use fallback destination buffer size of CMP_HDR_MAX_COMPRESSED_SIZE.\n"
+				"         Compressed data may not fit into the destination buffer!\n");
+		} else {
+			fprintf(stderr,
+				"Error calculating destination buffer size: %s. (Error Code: %u)\n",
+				cmp_get_error_message(dst_capacity),
+				cmp_get_error_code(dst_capacity));
+			free(work_buf);
+			return -1;
+		}
 	}
 
 	/* Allocate destination buffer */
 	dst = malloc(dst_capacity);
 	if (dst == NULL) {
 		fprintf(stderr, "Memory allocation failed for destination buffer\n");
+		free(work_buf);
 		return -1;
 	}
 
@@ -144,12 +155,12 @@ static int simple_compression(void)
 	/*
 	 * Step 5: Compress Data
 	 */
-	{ /* The first data we want to "compress" */
-		uint16_t data1[DATA_SAMPLES] = { 0x0000, 0x0001, 0x0002 };
+	{ /* Data we want to "compress" */
+		uint16_t data[DATA_SAMPLES_EXAMPLE] = { 0x0000, 0x0001, 0x0002 };
 
-		cmp_size = cmp_compress_u16(&ctx, dst, dst_capacity, data1, sizeof(data1));
+		cmp_size = cmp_compress_u16(&ctx, dst, dst_capacity, data, sizeof(data));
 		if (cmp_is_error(cmp_size)) { /* check compression result */
-			fprintf(stderr, "First data compression failed: %s. (Error Code: %u)\n",
+			fprintf(stderr, "Data compression failed: %s. (Error Code: %u)\n",
 				cmp_get_error_message(cmp_size), cmp_get_error_code(cmp_size));
 			free(dst);
 			free(work_buf);
@@ -160,12 +171,12 @@ static int simple_compression(void)
 
 	/*
 	 * Step 6: Use the Compressed Data
-	 * Lets have a look at the compressed data.
+	 * In this example, only the compressed data are printed.
 	 */
 	{
 		uint32_t i;
 
-		printf(" First Compressed Data (Size: %" PRIu32 "):\n", cmp_size);
+		printf("Compressed Data (Size: %" PRIu32 "):\n", cmp_size);
 		for (i = 0; i < cmp_size; i++)
 			printf("%02X%s", dst[i], ((i + 1) % 32 == 0) ? "\n" : " ");
 		printf("\n");
@@ -173,30 +184,8 @@ static int simple_compression(void)
 
 
 	/*
-	 * Repeat Step 5 until you compressed enough data
+	 * Repeat Step 5 and 6 until you compressed enough data
 	 */
-	{ /* The second data buffer we want to "compress". */
-		/* NOTE: Data size should be the same as before */
-		uint16_t data2[DATA_SAMPLES] = { 0xCA75, 0xCAFE, 0xC0DE };
-
-		cmp_size = cmp_compress_u16(&ctx, dst, dst_capacity, data2, sizeof(data2));
-		if (cmp_is_error(cmp_size)) {
-			fprintf(stderr, "Second data compression failed: %s. (Error Code: %u)\n",
-				cmp_get_error_message(cmp_size), cmp_get_error_code(cmp_size));
-			free(dst);
-			free(work_buf);
-			return -1;
-		}
-	}
-
-	{ /* Lets have a look at the compressed data. */
-		uint32_t i;
-
-		printf("Second Compressed Data (Size: %" PRIu32 "):\n", cmp_size);
-		for (i = 0; i < cmp_size; i++)
-			printf("%02X%s", dst[i], ((i + 1) % 32 == 0) ? "\n" : " ");
-		printf("\n");
-	}
 
 
 	/*
@@ -223,7 +212,7 @@ static int simple_compression(void)
 	 * Step 8: Clean-up
 	 * Free allocated resources.
 	 */
-	cmp_deinitialise(&ctx); /* this is optional */
+	cmp_deinitialise(&ctx); /* this is optional, clears the state of ctx  */
 	free(dst);
 	free(work_buf);
 


### PR DESCRIPTION
- Fix memory leaks
- Simplifies the example by removing a redundant compression pass.
- Add a fallback for dst_capacity if cmp_compress_bound() fails