### PR TITLE
feat(cli): Implement compression parameter parsing

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -80,6 +80,8 @@
  */
 #define bitsizeof(x) (8 * sizeof(x))
 
+#define maximum_signed_value_of_type(a) (INTMAX_MAX >> (bitsizeof(intmax_t) - bitsizeof(a)))
+#define maximum_unsigned_value_of_type(a) (UINTMAX_MAX >> (bitsizeof(uintmax_t) - bitsizeof(a)))
 
 /**
  * @brief marks a function parameter that is always unused.

--- a/programs/airspacecli.c
+++ b/programs/airspacecli.c
@@ -19,6 +19,7 @@
 #include "file.h"
 #include "log.h"
 #include "util.h"
+#include "params_parse.h"
 
 /* Program information */
 #define PROGRAM_NAME "AIRSPACE CLI"
@@ -304,17 +305,18 @@ int main(int argc, char *argv[])
 		DEBUG_STDOUT_CONSOLE_OPT
 	};
 	static struct option long_options[] = {
-		{ "compress",               no_argument, NULL, 'c'                      },
-		{ "stdout",                 no_argument, NULL, STDOUT_OPT               },
-		{ "verbose",                no_argument, NULL, 'v'                      },
-		{ "quiet",                  no_argument, NULL, 'q'                      },
-		{ "color",                  no_argument, NULL, COLOR_OPT                },
-		{ "no-color",               no_argument, NULL, NO_COLOR_OPT             },
-		{ "version",                no_argument, NULL, 'V'                      },
-		{ "help",                   no_argument, NULL, 'h'                      },
-		{ "debug-stdin-is-consol",  no_argument, NULL, DEBUG_STDIN_CONSOLE_OPT  },
-		{ "debug-stdout-is-consol", no_argument, NULL, DEBUG_STDOUT_CONSOLE_OPT },
-		{ NULL,                     0,           NULL, 0                        }
+		{ "compress",               no_argument,       NULL, 'c'                      },
+		{ "params",                 required_argument, NULL, 'p'                      },
+		{ "stdout",                 no_argument,       NULL, STDOUT_OPT               },
+		{ "verbose",                no_argument,       NULL, 'v'                      },
+		{ "quiet",                  no_argument,       NULL, 'q'                      },
+		{ "color",                  no_argument,       NULL, COLOR_OPT                },
+		{ "no-color",               no_argument,       NULL, NO_COLOR_OPT             },
+		{ "version",                no_argument,       NULL, 'V'                      },
+		{ "help",                   no_argument,       NULL, 'h'                      },
+		{ "debug-stdin-is-consol",  no_argument,       NULL, DEBUG_STDIN_CONSOLE_OPT  },
+		{ "debug-stdout-is-consol", no_argument,       NULL, DEBUG_STDOUT_CONSOLE_OPT },
+		{ NULL,                     0,                 NULL, 0                        }
 	};
 
 	const char *program_name;
@@ -336,6 +338,12 @@ int main(int argc, char *argv[])
 		switch (ch) {
 		case 'c':
 			mode = MODE_COMPRESS;
+			break;
+		case 'p':
+			if (cmp_params_parse(optarg, &params) != CMP_PARSE_OK) {
+				LOG_ERROR("Incorrect parameter option: %s", argv[optind-1]);
+				return EXIT_FAILURE;
+			}
 			break;
 		case 'o':
 			output_filename = optarg;

--- a/programs/arena.h
+++ b/programs/arena.h
@@ -1,0 +1,87 @@
+/**
+ * @file
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2025
+ * @copyright GPL-2.0
+ *
+ * @brief A simple, single-threaded, linear memory arena (bump allocator)
+ *
+ * @see for more details https://nullprogram.com/blog/2023/09/27/
+ */
+
+#ifndef ARENA_H
+#define ARENA_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <assert.h>
+
+#define ARENA_NEW(a, t)          ((t *)arena_alloc(a, 1, sizeof(t), __alignof__(t)))
+#define ARENA_NEW_ARRAY(a, n, t) ((t *)arena_alloc(a, n, sizeof(t), __alignof__(t)))
+
+struct arena {
+	uint8_t *beg;
+	uint8_t *end;
+};
+
+#include <stdlib.h>
+static void __attribute__((noreturn)) oom(void)
+{
+	exit(3);
+}
+
+
+/**
+ * @brief allocates a zero-initialized block of memory from the arena with specified alignment
+ *
+ * @param a	pointer to the arena
+ * @param count	number of elements to allocate
+ * @param size	size of each element
+ * @param align	the desired alignment, must be a power of two
+ *
+ * @returns a pointer to the allocated memory; calls oom() on failure.
+ */
+
+static __inline void *arena_alloc(struct arena *a, ptrdiff_t count, ptrdiff_t size, ptrdiff_t align)
+{
+	ptrdiff_t padding, available;
+	uint8_t *r;
+
+	assert(count >= 0);
+	assert(size > 0);
+	assert(align > 0 && (align & (align - 1)) == 0 && "Alignment must be a power of two");
+
+	padding = (ptrdiff_t)-(size_t)a->beg & (align - 1);
+	available = a->end - a->beg - padding;
+	if (available < 0 || count > available / size)
+		oom();
+
+	r = a->beg + padding;
+	a->beg += padding + count * size;
+	memset(r, 0, (size_t)(count * size));
+	return r;
+}
+
+
+/**
+ * @brief checks if a memory block can be resized
+ *
+ * @param a	arena to check against
+ * @param ptr	pointer to the memory block to check
+ * @param size	the current size of the memory block at ptr
+ *
+ * @returns non-zero if the block can be possible resized, 0 otherwise
+ */
+
+static __inline int arena_is_resize_possible(struct arena a, const void *ptr, ptrdiff_t size)
+{
+	assert(a.beg && a.end);
+	assert(size >= 0);
+
+	/* In a bump allocator, only the last allocation can be extended in-place */
+	return ptr && ((const uint8_t *)ptr + size) == a.beg;
+}
+
+#endif /* ARENA_H */

--- a/programs/log.h
+++ b/programs/log.h
@@ -103,11 +103,11 @@ __extension__
  * @param cmp_ret_val	return value from a (de)compression library function
  * @param ...		format string and arguments for the message
  */
-#define LOG_ERROR_CMP(cmp_ret_val, ...)                                                            \
-	do {                                                                                       \
-		LOG_PREFIX(LOG_LEVEL_ERROR, "error", LOG_COLOR_ERROR, __VA_ARGS__);                \
-		LOG_PLAIN(LOG_LEVEL_ERROR, "%s (error: %d)\n", cmp_get_error_message(cmp_ret_val), \
-			  cmp_get_error_code(cmp_ret_val));                                        \
+#define LOG_ERROR_CMP(cmp_ret_val, ...)                                                         \
+	do {                                                                                    \
+		LOG_PREFIX(LOG_LEVEL_ERROR, "error", LOG_COLOR_ERROR, __VA_ARGS__);             \
+		LOG_PLAIN(LOG_LEVEL_ERROR, ": %s (compression error: %d)\n",                    \
+			  cmp_get_error_message(cmp_ret_val), cmp_get_error_code(cmp_ret_val)); \
 	} while (0)
 
 

--- a/programs/meson.build
+++ b/programs/meson.build
@@ -1,15 +1,22 @@
 cli_src = files([
-  'airspacecli.c',
+  'params_parse.c',
   'log.c',
   'file.c',
   'util.c'
 ])
 
-airspacecli = executable('airspace',
+cli_lib = static_library('airspace_cli',
   cli_src,
+  include_directories: [inc_cmp],
+  implicit_include_directories: false,
+  c_args : non_testing_flags,
+  install: false)
+
+airspacecli = executable('airspace',
+  'airspacecli.c',
   include_directories : inc_cmp,
   implicit_include_directories: false,
-  link_with : cmp_lib,
+  link_with : [cli_lib, cmp_lib],
   c_args : '-D_POSIX_C_SOURCE=1', # This is needed for some stdio.h function in Linux with ANSI C
   install: true)
 

--- a/programs/params_parse.c
+++ b/programs/params_parse.c
@@ -1,0 +1,396 @@
+/**
+ * @file
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2025
+ * @copyright GPL-2.0
+ *
+ * @brief Parsing and printing functions for the compression parameters
+ */
+
+#include <string.h>
+#include <assert.h>
+
+#include "../lib/common/compiler.h"
+#include "cmp.h"
+#include "log.h"
+#include "params_parse.h"
+#include "arena.h"
+#define STR_SLICE_IMPLEMENTATION
+#define STR_SLICE_API static __inline
+#include "str_slice.h"
+
+
+/* Represents a mapping from a string name to an integer value */
+struct map_entry {
+	struct s8 name;
+	uint32_t value;
+};
+struct value_map {
+	const struct map_entry *entries;
+	size_t entry_count;
+	const struct s8 *prefixes;
+	size_t prefix_count;
+};
+
+static const struct map_entry preprocessing_entries[] = {
+	{ S8("NONE"),  CMP_PREPROCESS_NONE  },
+	{ S8("DIFF"),  CMP_PREPROCESS_DIFF  },
+	{ S8("IWT"),   CMP_PREPROCESS_IWT   },
+	{ S8("MODEL"), CMP_PREPROCESS_MODEL }
+};
+static const struct s8 preprocessing_prefixes[] = { S8("CMP_PREPROCESS_"), S8("CMP_"),
+						    S8("PREPROCESS_") };
+static const struct value_map preprocessing_map = {
+	preprocessing_entries,
+	ARRAY_SIZE(preprocessing_entries),
+	preprocessing_prefixes,
+	ARRAY_SIZE(preprocessing_prefixes),
+};
+
+static const struct map_entry encoder_type_entries[] = {
+	{ S8("UNCOMPRESSED"), CMP_ENCODER_UNCOMPRESSED },
+	{ S8("GOLOMB_ZERO"),  CMP_ENCODER_GOLOMB_ZERO  },
+	{ S8("GOLOMB_MULTI"), CMP_ENCODER_GOLOMB_MULTI }
+};
+static const struct s8 encoder_type_prefixes[] = { S8("CMP_ENCODER_"), S8("CMP_"), S8("ENCODER_") };
+static const struct value_map encoder_type_map = {
+	encoder_type_entries,
+	ARRAY_SIZE(encoder_type_entries),
+	encoder_type_prefixes,
+	ARRAY_SIZE(encoder_type_prefixes),
+};
+
+static const struct map_entry bool_entries[] = {
+	{ S8("FALSE"), 0 },
+	{ S8("TRUE"),  1 },
+	{ S8("0"),     0 },
+	{ S8("1"),     1 }
+};
+static const struct s8 bool_prefixes[] = { S8("CMP_") };
+static const struct value_map bool_map = {
+	bool_entries,
+	ARRAY_SIZE(bool_entries),
+	bool_prefixes,
+	ARRAY_SIZE(bool_prefixes),
+};
+
+/* Helper macro for defining cmp_params struct fields */
+#define PARAM_FIELD(f) offsetof(struct cmp_params, f), sizeof(((struct cmp_params *)0)->f)
+
+/*
+ * Dispatch table to map parameter names to their type and location within the
+ * cmp_params struct.
+ */
+static const struct param_def {
+	struct s8 name;
+	size_t offset;
+	size_t size;
+	const struct value_map *value_map; /* NULL for uint32_t */
+} param_keys[] = {
+	/* Primary compression parameters */
+	{ S8("primary_preprocessing"),         PARAM_FIELD(primary_preprocessing),         &preprocessing_map },
+	{ S8("primary_encoder_type"),          PARAM_FIELD(primary_encoder_type),          &encoder_type_map  },
+	{ S8("primary_encoder_param"),         PARAM_FIELD(primary_encoder_param),         NULL               },
+	{ S8("primary_encoder_outlier"),       PARAM_FIELD(primary_encoder_outlier),       NULL               },
+	{ S8("secondary_iterations"),          PARAM_FIELD(secondary_iterations),          NULL               },
+
+	/* Secondary compression parameters */
+	{ S8("secondary_preprocessing"),       PARAM_FIELD(secondary_preprocessing),       &preprocessing_map },
+	{ S8("secondary_encoder_type"),        PARAM_FIELD(secondary_encoder_type),        &encoder_type_map  },
+	{ S8("secondary_encoder_param"),       PARAM_FIELD(secondary_encoder_param),       NULL               },
+	{ S8("secondary_encoder_outlier"),     PARAM_FIELD(secondary_encoder_outlier),     NULL               },
+	{ S8("model_rate"),                    PARAM_FIELD(model_rate),                    NULL               },
+
+	/* Feature flags */
+	{ S8("checksum_enabled"),              PARAM_FIELD(checksum_enabled),              &bool_map          },
+	{ S8("uncompressed_fallback_enabled"), PARAM_FIELD(uncompressed_fallback_enabled), &bool_map          }
+};
+#undef PARAM_FIELD
+
+
+/* Write a value to a field in a cmp_params struct */
+static void write_struct_field(struct cmp_params *params, const struct param_def *def, uint32_t val)
+{
+	void *addr = (uint8_t *)params + def->offset;
+
+	switch (def->size) {
+	case sizeof(uint8_t): {
+		uint8_t u8 = (uint8_t)val;
+
+		assert(u8 == val);
+		memcpy(addr, &u8, def->size);
+		break;
+	}
+	case sizeof(uint16_t): {
+		uint16_t u16 = (uint16_t)val;
+
+		assert(u16 == val);
+		memcpy(addr, &u16, def->size);
+		break;
+	}
+	case sizeof(uint32_t):
+		memcpy(addr, &val, def->size);
+		break;
+	default:
+		LOG_ERROR("This should never happen if the parameter definitions are correct");
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+/* Read a value from a field in a cmp_params struct */
+static uint32_t read_struct_field(const struct cmp_params *params, const struct param_def *def)
+{
+	const uint8_t *addr = (const uint8_t *)params + def->offset;
+
+	switch (def->size) {
+	case sizeof(uint8_t): {
+		uint8_t val;
+
+		memcpy(&val, addr, sizeof(val));
+		return val;
+	}
+	case sizeof(uint16_t): {
+		uint16_t val;
+
+		memcpy(&val, addr, sizeof(val));
+		return val;
+	}
+	case sizeof(uint32_t): {
+		uint32_t val;
+
+		memcpy(&val, addr, sizeof(val));
+		return val;
+	}
+	default:
+		LOG_ERROR("This should never happen if the parameter definitions are correct");
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+static const struct param_def *find_param_definition(struct s8 key)
+{
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(param_keys); i++)
+		if (s8_equals_ignore_case(key, param_keys[i].name))
+			return &param_keys[i];
+
+	return NULL;
+}
+
+
+static struct s8 s8_strip_prefixes_ignore_case(struct s8 s, const struct value_map *map)
+{
+	size_t i;
+
+	for (i = 0; i < map->prefix_count; i++)
+		if (s8_starts_with_ignore_case(s, map->prefixes[i]))
+			return s8_skip(s, map->prefixes[i].len);
+	return s;
+}
+
+
+static void log_valid_values(const struct param_def *def)
+{
+	size_t i;
+
+	if (!def->value_map) {
+		LOG_INFO("Hint: Value for '" PRIs8 "' must be a whole number.", S8_PARG(def->name));
+		return;
+	}
+
+	LOG_INFO("Hint: Valid options for '" PRIs8 "' are:", S8_PARG(def->name));
+	for (i = 0; i < def->value_map->entry_count; i++)
+		LOG_INFO("  - '" PRIs8 "'", S8_PARG(def->value_map->entries[i].name));
+}
+
+
+static enum cmp_parse_status parse_value_str(const struct value_map *map, struct s8 value_str,
+					     uint32_t *value_num)
+{
+	size_t i;
+
+	*value_num = 0;
+
+	if (map) {
+		value_str = s8_strip_prefixes_ignore_case(value_str, map);
+		for (i = 0; i < map->entry_count; i++) {
+			if (s8_equals_ignore_case(value_str, map->entries[i].name)) {
+				*value_num = map->entries[i].value;
+				return CMP_PARSE_OK;
+			}
+		}
+	} else { /* Handle uint32_t parameters */
+		struct s8_u32_result result = s8_to_u32(value_str);
+
+		if (result.ok) {
+			*value_num = result.value;
+			return CMP_PARSE_OK;
+		}
+	}
+	return CMP_PARSE_INVALID_VALUE;
+}
+
+
+/* Parses a single "key=value" pair and updates the params struct */
+static enum cmp_parse_status cmp_param_parse_kv_pair(struct s8 key, struct s8 value,
+						     struct cmp_params *params)
+{
+	const struct param_def *key_def;
+	uint32_t value_num;
+	enum cmp_parse_status status;
+
+	key = s8_trim(key);
+	value = s8_trim(value);
+
+	key_def = find_param_definition(key);
+	if (!key_def) {
+		LOG_ERROR("Unknown compression parameter: '" PRIs8 "'", S8_PARG(key));
+		return CMP_PARSE_INVALID_KEY;
+	}
+
+	status = parse_value_str(key_def->value_map, value, &value_num);
+	if (status == CMP_PARSE_OK) {
+		write_struct_field(params, key_def, value_num);
+	} else {
+		LOG_ERROR("Invalid value '" PRIs8 "' for parameter '" PRIs8 "'.", S8_PARG(value),
+			  S8_PARG(key));
+		log_valid_values(key_def);
+	}
+	return status;
+}
+
+
+enum cmp_parse_status cmp_params_parse(const char *str, struct cmp_params *params)
+{
+	struct s8 remaining = s8_trim(s8_from_cstr(str));
+	int saw_any = 0;
+
+	while (remaining.len > 0) {
+		enum cmp_parse_status r;
+		struct s8 kv_pair;
+		struct s8_split_result split;
+
+		split = s8_split_at(remaining, ',');
+		remaining = split.tail;
+		kv_pair = s8_trim(split.head);
+		if (!kv_pair.len)
+			continue; /* Handles trailing or double commas */
+
+		split = s8_split_at(kv_pair, '=');
+		if (!split.ok) {
+			LOG_ERROR("Parameters string is missing '=': '" PRIs8 "'.",
+				  S8_PARG(kv_pair));
+			return CMP_PARSE_MISSING_EQUAL;
+		}
+
+		r = cmp_param_parse_kv_pair(split.head, split.tail, params);
+		if (r != CMP_PARSE_OK)
+			return r;
+		saw_any = 1;
+	}
+
+	if (!saw_any) {
+		LOG_ERROR("Empty parameter string.");
+		return CMP_PARSE_EMPTY_STR;
+	}
+
+	return CMP_PARSE_OK;
+}
+
+
+/* Return a copy of a string */
+static struct s8 s8_clone(struct arena *a, struct s8 s)
+{
+	struct s8 r = { 0 };
+	unsigned char *clone;
+
+	clone = ARENA_NEW_ARRAY(a, s.len, unsigned char);
+	if (s.s)
+		memcpy(clone, s.s, (size_t)s.len);
+	r.s = (const unsigned char *)clone;
+	r.len = s.len;
+	return r;
+}
+
+
+/* Concatenate two strings using arena allocation. */
+static struct s8 s8_concat(struct arena *a, struct s8 head, struct s8 tail)
+{
+	struct s8 r = { 0 };
+
+	if (arena_is_resize_possible(*a, head.s, head.len))
+		r = head;
+	else
+		r = s8_clone(a, head);
+
+	tail = s8_clone(a, tail);
+	assert(tail.s == r.s + head.len && "Arena allocation must be contiguous");
+
+	r.len = head.len + tail.len;
+	return r;
+}
+
+
+/* Concatenate string with decimal representation of uint32_t */
+static struct s8 s8_concat_u32(struct arena *a, struct s8 head, uint32_t v)
+{
+	unsigned char b[10] = { 0 };
+	ptrdiff_t i = S8_COUNTOF(b);
+
+	do {
+		b[--i] = '0' + (unsigned char)(v % 10);
+	} while (v /= 10);
+
+	return s8_concat(a, head, s8_span(&b[i], &b[S8_COUNTOF(b)]));
+}
+
+
+static struct s8 concat_value_as_string(struct arena *a, struct s8 head,
+					const struct value_map *map, uint32_t value_num)
+{
+	static const struct s8 invalid = S8("INVALID");
+	size_t i;
+
+	if (!map)
+		return s8_concat_u32(a, head, value_num);
+
+	for (i = 0; i < map->entry_count; i++)
+		if (value_num == map->entries[i].value)
+			return s8_concat(a, head, map->entries[i].name);
+
+	return s8_concat(a, head, invalid);
+}
+
+
+const char *cmp_params_to_string(struct arena *a, const struct cmp_params *par)
+{
+	static const struct s8 eq = S8(" = ");
+	static const struct s8 new_line = S8(",\n");
+	static const struct s8 end = S8("\n\0");
+	struct s8 r = { 0 };
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(param_keys); i++) {
+		const struct param_def *key_def = &param_keys[i];
+		uint32_t numeric_val = 0;
+
+		r = s8_concat(a, r, key_def->name);
+		r = s8_concat(a, r, eq);
+
+		numeric_val = read_struct_field(par, key_def);
+		if (key_def->value_map == &bool_map)
+			numeric_val = !!numeric_val; /* Normalize boolean values to 0 or 1 */
+
+		r = concat_value_as_string(a, r, key_def->value_map, numeric_val);
+
+		if (i < ARRAY_SIZE(param_keys) - 1)
+			r = s8_concat(a, r, new_line);
+	}
+
+	r = s8_concat(a, r, end);
+
+	return (const char *)r.s;
+}

--- a/programs/params_parse.h
+++ b/programs/params_parse.h
@@ -1,0 +1,58 @@
+/**
+ * @file
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2025
+ * @copyright GPL-2.0
+ *
+ * @brief Parsing and printing functions for the compression parameters
+ */
+
+#ifndef PARAMS_PARSE_H
+#define PARAMS_PARSE_H
+
+#include "cmp.h"
+#include "log.h"
+#include "arena.h"
+
+enum cmp_parse_status {
+	CMP_PARSE_OK = 0,
+	CMP_PARSE_EMPTY_STR,
+	CMP_PARSE_MISSING_EQUAL,
+	CMP_PARSE_INVALID_KEY,
+	CMP_PARSE_INVALID_VALUE
+};
+
+/**
+ * @brief parses a "key=value,key2=value2" string of compression parameters and
+ * updates the params struct/
+ *
+ * @param str		A null-terminated C string containing key-value pairs.
+ *			The expected format is "key1=value1,key2=value2,...".
+ *			Whitespace around keys, values, '=', and ',' is tolerated.
+ *			If the keys are the same, the last one wins.
+ * @param params	A pointer to a 'struct cmp_params' to be populated with the
+ *			parsed values. Must not be NULL. no change when not
+ *			parsed
+ *
+ * @returns enum cmp_parse_status
+ *   - CMP_PARSE_OK		on success
+ *   - CMP_PARSE_EMPTY_STR	if the string contains no key=value pairs
+ *   - CMP_PARSE_MISSING_EQUAL	if a pair is missing '='
+ *   - CMP_PARSE_INVALID_KEY	if a key is unknown
+ *   - CMP_PARSE_INVALID_VALUE	if a value is malformed or not allowed for the field
+ *
+ * @note This function stops at the first error encountered.
+ */
+enum cmp_parse_status cmp_params_parse(const char *str, struct cmp_params *params);
+
+/**
+ * @brief serializes a struct cmp_params into a human-readable string
+ *
+ * @param perm	pointer to an arena used to build the output string
+ * @param par	pointer to the compression values to stringify
+ *
+ * @returns a pointer to a NUL-terminated string allocated within 'perm'
+ */
+const char *cmp_params_to_string(struct arena *perm, const struct cmp_params *par);
+
+#endif /* PARAMS_PARSE_H */

--- a/programs/str_slice.h
+++ b/programs/str_slice.h
@@ -1,0 +1,301 @@
+/**
+ * @file
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2025
+ * @copyright GPL-2.0
+ *
+ * @brief Lightweight string slice library for substring operations.
+ *
+ * @warning A slice is a borrowed view and is only valid as long as the
+ *          underlying buffer is valid. Do not return slices to stack-allocated
+ *          memory from a function.
+ *
+ * @warning Encoding: this library is byte-oriented. Case-insensitive and
+ *          whitespace helpers are ASCII-only (not Unicode/UTF-8 aware).
+ *
+ * @details To use this library, place this header file in your project.
+ *          To include the implementation, define STR_SLICE_IMPLEMENTATION in
+ *          file before including the header:
+ *
+ *          #define STR_SLICE_IMPLEMENTATION
+ *          #include "str_slice.h"
+ *
+ *          You can optionally define STR_SLICE_API to control API visibility
+ *          and linkage (e.g., static, extern).
+ *          By default, functions are static.
+ *
+ * This library is highly inspired by the string handling done in u-config by
+ * @author Christopher Wellons (skeeto)
+ */
+
+#ifndef STR_SLICE_H_MIKG4GPN
+#define STR_SLICE_H_MIKG4GPN
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef STR_SLICE_API
+#  define STR_SLICE_API static
+#endif
+
+
+/** String slice type (8-bit chars) */
+struct s8 {
+	const unsigned char *s; /**< not null terminated string */
+	ptrdiff_t len;          /**< length of string s */
+};
+
+/* Utility macros */
+#define S8_COUNTOF(a) ((ptrdiff_t)(sizeof(a) / sizeof(*(a))))
+/** Creates string slice from string literal @warning: do not use it with pointers! */
+#define S8(s) { (const unsigned char *)s, S8_COUNTOF(s) - 1 }
+
+/**
+ * printf format specifier for a string slice
+ * Example: printf("my_s8: %" PRIs8 "\n", S8_PARG(my_s8));
+ */
+#define PRIs8 "%.*s"
+/** Expands a string slice into the arguments required by PRIs8 */
+#define S8_PARG(x) (int)(x).len, (const char *)(x).s
+
+/** Create s8 string from C string */
+STR_SLICE_API struct s8 s8_from_cstr(const char *z);
+/** Create s8 string from C string with known length */
+STR_SLICE_API struct s8 s8_make(const char *z, ptrdiff_t len);
+/** Create s8 string from a pointer range [beg, end) */
+STR_SLICE_API struct s8 s8_span(const unsigned char *beg, const unsigned char *end);
+
+
+/** Check if two s8 strings are equal */
+STR_SLICE_API int s8_equals(struct s8 s1, struct s8 s2);
+/** Check if two s8 strings are equal, differences in case are ignored, ASCII-only (not UTF-8) */
+STR_SLICE_API int s8_equals_ignore_case(struct s8 s1, struct s8 s2);
+/** Check if string starts with specified substring */
+STR_SLICE_API int s8_starts_with(struct s8 s, struct s8 pre);
+STR_SLICE_API int s8_starts_with_ignore_case(struct s8 s, struct s8 pre);
+
+/** Take head portion of string */
+STR_SLICE_API struct s8 s8_prefix(struct s8 s, ptrdiff_t len);
+/** Remove head portion of string */
+STR_SLICE_API struct s8 s8_skip(struct s8 s, ptrdiff_t off);
+
+/** Remove whitespace from the begin and the end */
+STR_SLICE_API struct s8 s8_trim(struct s8 s);
+/** Remove prefix if present */
+STR_SLICE_API struct s8 s8_strip_prefix(struct s8 s, struct s8 pre);
+/** Remove prefix if present, differences in case are ignored, ASCII-only (not UTF-8) */
+STR_SLICE_API struct s8 s8_strip_prefix_ignore_case(struct s8 s, struct s8 pre);
+
+/** split_at() parsing result */
+struct s8_split_result {
+	struct s8 head;
+	struct s8 tail;
+	int ok;
+};
+/** Split string at delimiter */
+STR_SLICE_API struct s8_split_result s8_split_at(struct s8 s, unsigned char delim);
+
+/** s8_to_u32() parsing result */
+struct s8_u32_result {
+	uint32_t value;
+	int ok;
+};
+/** Parse unsigned 32-bit integer from string */
+STR_SLICE_API struct s8_u32_result s8_to_u32(struct s8 s);
+
+#endif /* STR_SLICE_H_MIKG4GPN */
+
+
+/* Implementation */
+#ifdef STR_SLICE_IMPLEMENTATION
+
+#include <stddef.h>
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+
+
+STR_SLICE_API struct s8 s8_from_cstr(const char *z)
+{
+	struct s8 r = { 0 };
+
+	if (z) {
+		size_t l = strlen(z);
+
+		assert(l <= PTRDIFF_MAX);
+		r.len = (ptrdiff_t)l;
+		r.s = (const unsigned char *)z;
+	}
+	return r;
+}
+
+STR_SLICE_API struct s8 s8_make(const char *z, ptrdiff_t len)
+{
+	struct s8 r = { 0 };
+
+	if (len < 0)
+		return r;
+
+	r.s = (const unsigned char *)z;
+	r.len = len;
+	return r;
+}
+
+STR_SLICE_API struct s8 s8_span(const unsigned char *beg, const unsigned char *end)
+{
+	struct s8 r = { 0 };
+
+	assert(beg);
+	assert(end);
+	assert(end >= beg);
+	r.s = (const unsigned char *)beg;
+	r.len = end - beg;
+	return r;
+}
+
+/* Compare two byte arrays */
+static int u8_compare(const unsigned char *s1, const unsigned char *s2, ptrdiff_t n)
+{
+	assert(n >= 0);
+	return memcmp(s1, s2, (size_t)n);
+}
+
+STR_SLICE_API int s8_equals(struct s8 s1, struct s8 s2)
+{
+	return s1.len == s2.len && !u8_compare(s1.s, s2.s, s1.len);
+}
+
+/* ASCII-only case conversion (not UTF-8) */
+static unsigned char u8_to_upper(unsigned char c)
+{
+	return (c >= 'a' && c <= 'z') ? c - ('a' - 'A') : c;
+}
+
+/* Compare two byte arrays, differences in case are ignored, ASCII-only (not UTF-8) */
+static int u8_compare_ignore_case(const unsigned char *a, const unsigned char *b, ptrdiff_t n)
+{
+	for (; n; n--) {
+		int d = u8_to_upper(*a++) - u8_to_upper(*b++);
+
+		if (d)
+			return d;
+	}
+	return 0;
+}
+
+STR_SLICE_API int s8_equals_ignore_case(struct s8 a, struct s8 b)
+{
+	return a.len == b.len && !u8_compare_ignore_case(a.s, b.s, a.len);
+}
+
+STR_SLICE_API int s8_starts_with(struct s8 s, struct s8 pre)
+{
+	return (s.len >= pre.len) && s8_equals(s8_prefix(s, pre.len), pre);
+}
+
+STR_SLICE_API int s8_starts_with_ignore_case(struct s8 s, struct s8 pre)
+{
+	return (s.len >= pre.len) && s8_equals_ignore_case(s8_prefix(s, pre.len), pre);
+}
+
+STR_SLICE_API struct s8 s8_prefix(struct s8 s, ptrdiff_t len)
+{
+	assert(len >= 0);
+	assert(len <= s.len);
+	s.len = len;
+	return s;
+}
+
+STR_SLICE_API struct s8 s8_skip(struct s8 s, ptrdiff_t off)
+{
+	assert(off >= 0);
+	assert(off <= s.len);
+	s.s += off;
+	s.len -= off;
+	return s;
+}
+
+static int u8_is_whitespace(unsigned char c)
+{
+	return c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '\v' || c == '\f';
+}
+
+STR_SLICE_API struct s8 s8_trim(struct s8 s)
+{
+	const unsigned char *p, *e;
+
+	if (!s.len)
+		return s;
+
+	assert(s.s);
+	p = s.s;
+	e = s.s + s.len;
+
+	while (p < e && u8_is_whitespace(*p))
+		p++;
+	while (e > p && u8_is_whitespace(*(e - 1)))
+		e--;
+	return s8_span(p, e);
+}
+
+STR_SLICE_API struct s8 s8_strip_prefix(struct s8 s, struct s8 pre)
+{
+	if (s8_starts_with(s, pre))
+		return s8_skip(s, pre.len);
+	return s;
+}
+
+STR_SLICE_API struct s8 s8_strip_prefix_ignore_case(struct s8 s, struct s8 pre)
+{
+	if (s8_starts_with_ignore_case(s, pre))
+		return s8_skip(s, pre.len);
+	return s;
+}
+
+STR_SLICE_API struct s8_split_result s8_split_at(struct s8 s, unsigned char delim)
+{
+	struct s8_split_result r = { 0 };
+	ptrdiff_t len = 0;
+
+	for (len = 0; len < s.len; len++)
+		if (s.s[len] == delim)
+			break;
+
+	if (len == s.len) {
+		r.head = s;
+		r.tail = s8_skip(s, s.len);
+		return r;
+	}
+	r.head = s8_prefix(s, len);
+	r.tail = s8_skip(s, len + 1);
+	r.ok = 1;
+	return r;
+}
+
+STR_SLICE_API struct s8_u32_result s8_to_u32(struct s8 s)
+{
+	struct s8_u32_result r = { 0 };
+	uint32_t value = 0;
+	ptrdiff_t i = 0;
+
+	if (s.len == 0)
+		return r;
+	if (s.len > 1 && s.s[0] == '0') /* reject leading 0 */
+		return r;
+
+	for (; i < s.len; i++) {
+		uint32_t const d = s.s[i] - '0';
+
+		if (d > 9)
+			return r; /* Not a digit */
+		if (value > (UINT32_MAX - d) / 10)
+			return r;
+		value = value * 10 + d;
+	}
+
+	r.value = value;
+	r.ok = 1;
+	return r;
+}
+
+#endif /* STR_SLICE_IMPLEMENTATION */

--- a/test/meson.build
+++ b/test/meson.build
@@ -68,6 +68,7 @@ if ruby.found()
     'test_cmp_errors.c',
     'test_preprocessing.c',
     'test_encoder.c',
+    'test_params_parse.c',
     'test_buildsetup.c'])
 
   foreach test_file : unit_test_src
@@ -77,7 +78,7 @@ if ruby.found()
     test_exe = executable(test_name, test_file, test_runner,
       include_directories : inc_cmp,
       c_args : ['-DCMP_MESON_BUILD_ROOT="' + meson.project_build_root() + '/"'],
-      link_with : [test_lib, cmp_lib],
+      link_with : [test_lib, cmp_lib, cli_lib],
       dependencies : [unity_dep])
 
     test(test_name.replace('test_', '') + ' units tests',

--- a/test/test_params_parse.c
+++ b/test/test_params_parse.c
@@ -1,0 +1,531 @@
+/**
+ * @file
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2025
+ * @copyright GPL-2.0
+ *
+ * @brief Test configuration parser and serializes functionality
+ */
+
+#include <string.h>
+#include <unity.h>
+
+#include "../programs/params_parse.h"
+#include "../lib/common/compiler.h"
+
+
+/*
+ * The arena's state is completely reset on each call, providing a fresh scratch
+ * space for the caller. Consequently, any data allocated from the arena
+ * in previous calls becomes invalid.
+ */
+static struct arena *create_test_arena(void)
+{
+	static uint8_t mem[1 << 10];
+	static struct arena a;
+
+	memset(mem, 0x1D, ARRAY_SIZE(mem)); /* poison arena memory */
+	a.beg = mem;
+	a.end = mem + ARRAY_SIZE(mem);
+	return &a;
+}
+
+
+void test_parse_preprocess_enums(void)
+{
+	static const struct {
+		const char *name;
+		uint32_t value;
+	} preprocess_cases[] = {
+		{ "NONE",                CMP_PREPROCESS_NONE  },
+		{ "DIFF",                CMP_PREPROCESS_DIFF  },
+		{ "IWT",                 CMP_PREPROCESS_IWT   },
+		{ "MODEL",               CMP_PREPROCESS_MODEL },
+		{ "DiFf",                CMP_PREPROCESS_DIFF  },
+		{ "PREPROCESS_DIFF",     CMP_PREPROCESS_DIFF  },
+		{ "CMP_PREPROCESS_DIFF", CMP_PREPROCESS_DIFF  },
+		{ "CMP_DIFF",            CMP_PREPROCESS_DIFF  },
+		{ "CmP_pRePrOcEsS_dIfF", CMP_PREPROCESS_DIFF  }
+	};
+
+	size_t i;
+	struct arena *a = create_test_arena();
+	unsigned int const s_size = 64;
+	char *s = ARENA_NEW_ARRAY(a, s_size, char);
+	struct cmp_params par, par_exp;
+	enum cmp_parse_status status;
+
+	for (i = 0; i < ARRAY_SIZE(preprocess_cases); i++) {
+		memset(&par_exp, 0xff, sizeof(par_exp));
+		par_exp.primary_preprocessing = preprocess_cases[i].value;
+		snprintf(s, s_size, "primary_preprocessing=%s", preprocess_cases[i].name);
+		memset(&par, 0xff, sizeof(par));
+
+		status = cmp_params_parse(s, &par);
+
+		TEST_ASSERT_EQUAL_MESSAGE(CMP_PARSE_OK, status, s);
+		TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&par_exp, &par, sizeof(par_exp), s);
+	}
+
+	for (i = 0; i < ARRAY_SIZE(preprocess_cases); i++) {
+		memset(&par_exp, 0xff, sizeof(par_exp));
+		par_exp.secondary_preprocessing = preprocess_cases[i].value;
+		snprintf(s, s_size, "secondary_preprocessing=%s", preprocess_cases[i].name);
+		memset(&par, 0xff, sizeof(par));
+
+		status = cmp_params_parse(s, &par);
+
+		TEST_ASSERT_EQUAL_MESSAGE(CMP_PARSE_OK, status, s);
+		TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&par_exp, &par, sizeof(par_exp), s);
+	}
+}
+
+
+void test_parse_encoder_types_enums(void)
+{
+	static const struct {
+		const char *name;
+		uint32_t value;
+	} encoder_cases[] = {
+		{ "UNCOMPRESSED",             CMP_ENCODER_UNCOMPRESSED },
+		{ "GOLOMB_ZERO",              CMP_ENCODER_GOLOMB_ZERO  },
+		{ "GOLOMB_MULTI",             CMP_ENCODER_GOLOMB_MULTI },
+		{ "ENCODER_UNCOMPRESSED",     CMP_ENCODER_UNCOMPRESSED },
+		{ "CMP_ENCODER_UNCOMPRESSED", CMP_ENCODER_UNCOMPRESSED },
+		{ "CMP_UNCOMPRESSED",         CMP_ENCODER_UNCOMPRESSED },
+		{ "CmP_EnCoDeR_uNcOmPrEsSeD", CMP_ENCODER_UNCOMPRESSED }
+	};
+
+	size_t i;
+	struct arena *a = create_test_arena();
+	unsigned int const s_size = 64;
+	char *s = ARENA_NEW_ARRAY(a, s_size, char);
+	struct cmp_params par, par_exp;
+	enum cmp_parse_status status;
+
+	for (i = 0; i < ARRAY_SIZE(encoder_cases); i++) {
+		memset(&par_exp, 0xff, sizeof(par_exp));
+		par_exp.primary_encoder_type = encoder_cases[i].value;
+		snprintf(s, s_size, "primary_encoder_type=%s", encoder_cases[i].name);
+		memset(&par, 0xff, sizeof(par));
+
+		status = cmp_params_parse(s, &par);
+
+		TEST_ASSERT_EQUAL_MESSAGE(CMP_PARSE_OK, status, s);
+		TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&par_exp, &par, sizeof(par_exp), s);
+	}
+
+	for (i = 0; i < ARRAY_SIZE(encoder_cases); i++) {
+		memset(&par_exp, 0xff, sizeof(par_exp));
+		par_exp.secondary_encoder_type = encoder_cases[i].value;
+		snprintf(s, s_size, "secondary_encoder_type=%s", encoder_cases[i].name);
+		memset(&par, 0xff, sizeof(par));
+
+		status = cmp_params_parse(s, &par);
+
+		TEST_ASSERT_EQUAL_MESSAGE(CMP_PARSE_OK, status, s);
+		TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&par_exp, &par, sizeof(par_exp), s);
+	}
+}
+
+
+void test_parse_boolean_types(void)
+{
+	static const struct {
+		const char *name;
+		uint8_t value;
+	} boolean_cases[] = {
+		{ "TRUE",      1 },
+		{ "FALSE",     0 },
+		{ "1",         1 },
+		{ "0",         0 },
+		{ "CMP_TRUE",  1 },
+		{ "CMP_FALSE", 0 },
+		{ "Cmp_True",  1 },
+		{ "Cmp_False", 0 }
+	};
+
+	size_t i;
+	struct arena *a = create_test_arena();
+	unsigned int const s_size = 64;
+	char *s = ARENA_NEW_ARRAY(a, s_size, char);
+	struct cmp_params par, par_exp;
+	enum cmp_parse_status status;
+
+	for (i = 0; i < ARRAY_SIZE(boolean_cases); i++) {
+		memset(&par_exp, 0xff, sizeof(par_exp));
+		par_exp.checksum_enabled = boolean_cases[i].value;
+		snprintf(s, s_size, "checksum_enabled=%s", boolean_cases[i].name);
+		memset(&par, 0xff, sizeof(par));
+
+		status = cmp_params_parse(s, &par);
+
+		TEST_ASSERT_EQUAL_MESSAGE(CMP_PARSE_OK, status, s);
+		TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&par_exp, &par, sizeof(par_exp), s);
+	}
+}
+
+
+void test_parse_numeric_value_zero(void)
+{
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+
+	par.primary_encoder_param = ~0U;
+	par_exp.primary_encoder_param = 0;
+
+	status = cmp_params_parse("primary_encoder_param=0", &par);
+
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_parse_typical_numeric_value(void)
+{
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+
+	par_exp.primary_encoder_param = 42;
+
+	status = cmp_params_parse("primary_encoder_param=42", &par);
+
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_parse_maximum_numeric_value(void)
+{
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+
+	par_exp.primary_encoder_param =
+		maximum_unsigned_value_of_type(par_exp.primary_encoder_param);
+
+	status = cmp_params_parse("primary_encoder_param=4294967295", &par);
+
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_use_last_if_same_key_twice(void)
+{
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+
+	par_exp.primary_encoder_param = 42;
+
+	status = cmp_params_parse("primary_encoder_param=23,primary_encoder_param=42", &par);
+
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_trailing_comma_is_allowed(void)
+{
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+
+	par_exp.primary_preprocessing = CMP_PREPROCESS_MODEL;
+
+	status = cmp_params_parse(",primary_preprocessing=CMP_PREPROCESS_MODEL,", &par);
+
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_whitespace_is_allowed(void)
+{
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+
+	par_exp.primary_preprocessing = CMP_PREPROCESS_MODEL;
+
+	status = cmp_params_parse(" primary_preprocessing\t = CMP_PREPROCESS_MODEL\n", &par);
+
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_keys_are_case_insensitive(void)
+{
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+
+	par_exp.primary_encoder_param = 42;
+
+	status = cmp_params_parse("PrImArY_EnCoDeR_pArAm=42", &par);
+
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_parse_all_compression_parameters(void)
+{
+	/* arrange */
+	enum cmp_parse_status status;
+	struct cmp_params par = { 0 };
+	struct cmp_params par_exp = { 0 };
+	static const char *str = {
+		"primary_preprocessing = IWT,"
+		"primary_encoder_type = GOLOMB_MULTI,"
+		"primary_encoder_param = 12,"
+		"primary_encoder_outlier = 0,"
+
+		"secondary_iterations = 4294967295,"
+		"secondary_preprocessing = DIFF,"
+		"secondary_encoder_type = GOLOMB_ZERO,"
+		"secondary_encoder_param = 42,"
+		"secondary_encoder_outlier = 1,"
+		"model_rate = 16,"
+
+		"checksum_enabled = FALSE,"
+		"uncompressed_fallback_enabled = TRUE,"
+	};
+
+	par_exp.primary_preprocessing = CMP_PREPROCESS_IWT;
+	par_exp.primary_encoder_type = CMP_ENCODER_GOLOMB_MULTI;
+	par_exp.primary_encoder_param = 12;
+	par_exp.primary_encoder_outlier = 0;
+
+	par_exp.secondary_iterations = UINT32_MAX;
+	par_exp.secondary_preprocessing = CMP_PREPROCESS_DIFF;
+	par_exp.secondary_encoder_type = CMP_ENCODER_GOLOMB_ZERO;
+	par_exp.secondary_encoder_param = 42;
+	par_exp.secondary_encoder_outlier = 1;
+	par_exp.model_rate = 16;
+
+	par_exp.checksum_enabled = 0;
+	par_exp.uncompressed_fallback_enabled = 1;
+
+	/* act */
+	status = cmp_params_parse(str, &par);
+
+	/* assert */
+	TEST_ASSERT_EQUAL(CMP_PARSE_OK, status);
+	TEST_ASSERT_EQUAL_MEMORY(&par_exp, &par, sizeof(par_exp));
+}
+
+
+void test_detect_empty_string(void)
+{
+	size_t i;
+	static const char * const str[] = {
+		"", " ", "\t", "\r", "\n", ",", ", ,",
+	};
+
+	for (i = 0; i < ARRAY_SIZE(str); i++) {
+		struct cmp_params par;
+
+		enum cmp_parse_status status = cmp_params_parse(str[i], &par);
+
+		TEST_ASSERT_EQUAL_INT(CMP_PARSE_EMPTY_STR, status);
+	}
+}
+
+
+void test_detect_str_is_NULL(void)
+{
+	struct cmp_params par;
+
+	enum cmp_parse_status status = cmp_params_parse(NULL, &par);
+
+	TEST_ASSERT_EQUAL_INT(CMP_PARSE_EMPTY_STR, status);
+}
+
+
+void test_detects_invalid_syntax_missing_equals(void)
+{
+	size_t i;
+	static const char * const str[] = {
+		"primary_preprocessing CMP_PREPROCESS_MODEL",
+		"primary_preprocessing CMP_PREPROCESS_MODEL,",
+		"primary_preprocessingCMP_PREPROCESS_MODEL",
+	};
+
+	for (i = 0; i < ARRAY_SIZE(str); i++) {
+		struct cmp_params par;
+
+		enum cmp_parse_status status = cmp_params_parse(str[i], &par);
+
+		TEST_ASSERT_EQUAL_INT_MESSAGE(CMP_PARSE_MISSING_EQUAL, status, str[i]);
+	}
+}
+
+void test_detect_invalid_numeric_values(void)
+{
+	size_t i;
+	static const char * const str[] = {
+		"primary_encoder_param=4294967296", /* UINT32_MAX + 1 */
+		"primary_encoder_param=02",         "primary_encoder_param=000000000002",
+		"primary_encoder_param=2.2",        "primary_encoder_param=2.",
+		"primary_encoder_param=.2",         "primary_encoder_param=2 2",
+		"primary_encoder_param=-2",         "primary_encoder_param=0x2",
+		"primary_encoder_param=a",          "primary_encoder_param=",
+	};
+
+	for (i = 0; i < ARRAY_SIZE(str); i++) {
+		struct cmp_params par;
+
+		enum cmp_parse_status status = cmp_params_parse(str[i], &par);
+
+		TEST_ASSERT_EQUAL_INT_MESSAGE(CMP_PARSE_INVALID_VALUE, status, str[i]);
+	}
+}
+
+
+void test_detect_invalid_enum_keys(void)
+{
+	size_t i;
+	static const char * const str[] = {
+		"primary_preprocessing=",      "primary_preprocessing=,",
+		"primary_preprocessing=1",     "primary_preprocessing=DIF",
+		"primary_preprocessing==DIFF", "primary_preprocessing=DIF F",
+	};
+
+	for (i = 0; i < ARRAY_SIZE(str); i++) {
+		struct cmp_params par;
+
+		enum cmp_parse_status status = cmp_params_parse(str[i], &par);
+
+		TEST_ASSERT_EQUAL_INT_MESSAGE(CMP_PARSE_INVALID_VALUE, status, str[i]);
+	}
+}
+
+
+void test_detect_invalid_keys(void)
+{
+	struct cmp_params par;
+
+	enum cmp_parse_status status = cmp_params_parse("INVALID=3", &par);
+
+	TEST_ASSERT_EQUAL_INT(CMP_PARSE_INVALID_KEY, status);
+}
+
+void test_detect_no_keys(void)
+{
+	struct cmp_params par;
+
+	enum cmp_parse_status status = cmp_params_parse("=3", &par);
+
+	TEST_ASSERT_EQUAL_INT(CMP_PARSE_INVALID_KEY, status);
+}
+
+
+void test_stringify_all_parameters(void)
+{
+	struct arena *a = create_test_arena();
+	struct cmp_params par = { 0 };
+	const char *str;
+
+	/* arrange */
+	par.primary_preprocessing = (enum cmp_preprocessing)(-1);
+	par.primary_encoder_type = CMP_ENCODER_GOLOMB_MULTI;
+	par.primary_encoder_param = 12;
+
+	par.secondary_iterations = UINT32_MAX;
+	par.secondary_preprocessing = CMP_PREPROCESS_DIFF;
+	par.secondary_encoder_type = CMP_ENCODER_GOLOMB_ZERO;
+	par.secondary_encoder_param = 42;
+	par.secondary_encoder_outlier = 1;
+	par.model_rate = 16;
+
+	par.checksum_enabled = 0;
+	par.uncompressed_fallback_enabled = 1;
+
+	/* act */
+	str = cmp_params_to_string(a, &par);
+
+	/* assert */
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "primary_preprocessing = INVALID,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "primary_encoder_type = GOLOMB_MULTI,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "primary_encoder_param = 12,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "primary_encoder_outlier = 0,"), str);
+
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "secondary_iterations = 4294967295,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "secondary_preprocessing = DIFF,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "secondary_encoder_type = GOLOMB_ZERO,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "secondary_encoder_param = 42,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "secondary_encoder_outlier = 1,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "model_rate = 16,"), str);
+
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "checksum_enabled = FALSE,"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "uncompressed_fallback_enabled = TRUE\n"), str);
+	/* no ',' on last line*/
+}
+
+
+void test_to_string_bools_are_normalized(void)
+{
+	struct arena *a = create_test_arena();
+	struct cmp_params par = { 0 };
+	const char *s;
+
+	par.checksum_enabled = 42;
+
+	s = cmp_params_to_string(a, &par);
+
+	TEST_ASSERT_TRUE_MESSAGE(strstr(s, "checksum_enabled = TRUE"), s);
+}
+
+
+void test_stringify_invalid_enum_values(void)
+{
+	struct arena *a = create_test_arena();
+	struct cmp_params par = { 0 };
+	const char *str;
+
+	par.primary_preprocessing = (enum cmp_preprocessing)(-1);
+	par.primary_encoder_type = (enum cmp_encoder_type)(-2);
+	par.secondary_preprocessing = (enum cmp_preprocessing)(-3);
+	par.secondary_encoder_type = (enum cmp_encoder_type)(-4);
+
+	str = cmp_params_to_string(a, &par);
+
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "primary_preprocessing = INVALID"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "primary_encoder_type = INVALID"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "secondary_preprocessing = INVALID"), str);
+	TEST_ASSERT_TRUE_MESSAGE(strstr(str, "secondary_encoder_type = INVALID"), str);
+}
+
+
+void test_to_string_parse_roundtrip(void)
+{
+	struct arena *arena = create_test_arena();
+	struct cmp_params a = { 0 };
+	struct cmp_params b = { 0 };
+	const char *str;
+	enum cmp_parse_status status;
+
+	a.primary_preprocessing = CMP_PREPROCESS_NONE;
+	a.primary_encoder_type = CMP_ENCODER_GOLOMB_MULTI;
+	a.primary_encoder_param = 12;
+	a.primary_encoder_outlier = 0;
+	a.secondary_iterations = UINT32_MAX;
+	a.secondary_preprocessing = CMP_PREPROCESS_DIFF;
+	a.secondary_encoder_type = CMP_ENCODER_GOLOMB_ZERO;
+	a.secondary_encoder_param = 42;
+	a.secondary_encoder_outlier = 1;
+	a.model_rate = 16;
+	a.checksum_enabled = 0;
+	a.uncompressed_fallback_enabled = 1;
+
+	str = cmp_params_to_string(arena, &a);
+	status = cmp_params_parse(str, &b);
+
+	TEST_ASSERT_EQUAL_INT_MESSAGE(CMP_PARSE_OK, status, str);
+	TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&a, &b, sizeof(a), str);
+}


### PR DESCRIPTION
Add a --params (-p) command-line option to allow users to
configure compression parameters directly.

This provides a flexible way to tune compression settings. The
option accepts a comma-separated string of key=value pairs.
For example:
--params "primary_preprocessing=DIFF,secondary_iterations=0"

The new params_parse module implements the parsing logic. It handles
key-value pairs, supports various data types (enums, booleans,
integers), and is case-insensitive for keys and enum values. It also
includes a function to serialize the parameters back into a string.

To support this new functionality, two helper modules are introduced:

str_slice.h: A lightweight string slice library for efficient,
non-destructive string manipulation.
arena.h: A simple memory arena allocator for string building.