### PR TITLE
feat!(lib/cmp.h): Make timestamp provider API explicit

### DIFF
--- a/examples/simple_compression.c
+++ b/examples/simple_compression.c
@@ -14,27 +14,31 @@
 #include <stdio.h>
 #include <inttypes.h>
 
-#include "cmp.h"
-#include "cmp_errors.h"
-#include "cmp_header.h"
+#include <cmp.h>
+#include <cmp_errors.h>
+#include <cmp_header.h>
 
 
 /**
  * @brief Dummy timestamp function
  *
  * This function provides a simple dummy implementation for a timestamp provider.
- * It increments a static counter by 2 on each call and returns the result. This
- * function is intended for demonstration or testing purposes only.
- *
- * @returns a dummy 48-bit timestamp value
+ * It increments a static counter on each call and provides the result.
+ * This function is intended for demonstration or testing purposes only.
  */
 
-static uint64_t dummy_timestamp(void)
+static void dummy_timestamp(uint32_t *coarse, uint16_t *fine)
 {
-	static uint64_t dummy_time;
-	uint64_t const mask48 = (((uint64_t)1 << 48) - 1);
+	static uint32_t dummy_coarse_time;
+	static uint16_t dummy_fine_time;
 
-	return (dummy_time += 2) & mask48;
+	if (dummy_fine_time == UINT16_MAX)
+		dummy_coarse_time += 1;
+	dummy_fine_time += 1;
+
+
+	*coarse = dummy_coarse_time;
+	*fine = dummy_fine_time;
 }
 
 

--- a/lib/cmp.h
+++ b/lib/cmp.h
@@ -135,18 +135,19 @@ struct cmp_context {
 
 /* ======  Setup Functions   ====== */
 /**
- * @brief Sets a custom function to retrieve the current timestamp.
+ * @brief sets a custom function to retrieve the current timestamp
  *
- * This function allows to specify a custom function that returns a current
- * 48-bit timestamp. This timestamp is used by the compression for example, to
- * generate unique model identifiers.
+ * This function allows the library to use a user-provided function for
+ * generating model identifiers. The callback function must populate the
+ * coarse and fine values that will be combined into a 48-bit identifier.
  *
- * @param get_current_timestamp_func	pointer to a function returning a 48-bit
- *					timestamp; if NULL, a fallback function
- *					will be set
+ * @param get_current_timestamp_func	A function pointer that populates a
+ *					coarse (32-bit) and fine (16-bit)
+ *					timestamp. If NULL, the library reverts
+ *					to its default internal monotonic counter
  */
 
-void cmp_set_timestamp_func(uint64_t (*get_current_timestamp_func)(void));
+void cmp_set_timestamp_func(void (*get_current_timestamp_func)(uint32_t *coarse, uint16_t *fine));
 
 
 /* ====== Compression Helper Functions ====== */


### PR DESCRIPTION
This change refactors the timestamp provider to make this structure explicit. The cmp_set_timestamp_func callback now uses output parameters to request a 32-bit coarse value and a 16-bit fine value.

Update examples to the new function signature and behavior. Update tests and adding a check that a provided timestamp propagates to the header identifier.

BREAKING CHANGE: The signature of cmp_set_timestamp_func has changed. Instead of uint64_t (*)(void), it now requires a function pointer of type void (*)(uint32_t *coarse, uint16_t *fine). Users must update their timestamp callback functions to match the new signature.