### PR TITLE
Add CMP_UNCOMPRESSED_BOUND, docker support 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# VCS and metadata
+.git/
+.gitignore
+.gitmodules
+.github/
+
+# Meson subprojects: ignore everything except wraps and packagefiles
+subprojects/**
+!subprojects/*.wrap
+!subprojects/packagefiles/**
+
+# Editor/OS cruft
+*.swp
+*.swo
+.DS_Store
+
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Build outputs
+build/
+build_*/
+*_build/
+meson-logs/
+meson-private/
+
+# Tooling caches
+.cache/
+
+# Logs
+*.log
+
+# Compiled artifacts
+*.o
+*.a
+*.so
+*.dylib
+*.dll

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+FROM debian:trixie-slim AS builder
+
+# Install build-time and test dependencies
+# ruby is only needed for testing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    meson \
+    ruby && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy dependency files first to utilize layer caching for subprojects
+COPY subprojects ./subprojects/
+COPY meson.build ./
+RUN meson subprojects download
+
+COPY . .
+
+RUN meson setup build --buildtype=release --strip && \
+    meson compile -C build airspace && \
+    meson test -C build --print-errorlogs && \
+    meson install -C build --destdir /app/install --no-rebuild --skip-subprojects
+
+
+FROM debian:trixie-slim AS runtime
+
+RUN useradd -m appuser
+USER appuser
+
+COPY --from=builder /app/install/usr/local/bin/airspace /usr/local/bin/airspace
+
+ENTRYPOINT ["/usr/local/bin/airspace"]
+CMD ["--help"]

--- a/lib/cmp.h
+++ b/lib/cmp.h
@@ -105,7 +105,7 @@ struct cmp_params {
 	enum cmp_preprocessing secondary_preprocessing; /**< Preprocessing for secondary passes */
 	enum cmp_encoder_type secondary_encoder_type;   /**< Encoder for secondary passes */
 	uint32_t secondary_encoder_param;               /**< Parameter for the secondary encoder */
-	uint32_t secondary_encoder_outlier; /**< Secondary parameter for CMP_ENCODER_GOLOMB_MULTI */
+	uint32_t secondary_encoder_outlier; /**< Secondary outlier parameter for CMP_ENCODER_GOLOMB_MULTI */
 	uint32_t model_rate; /**< Model adaptation rate (used with CMP_PREPROCESS_MODEL) */
 
 	/* Additional Options */
@@ -169,6 +169,7 @@ unsigned int cmp_is_error(uint32_t code);
  *
  * In this scenario the input data are not compressible. This function is
  * primarily useful for memory allocation purposes (destination buffer size).
+ * Assumes a worst case configuration.
  *
  * @param size	size of the data to compress
  *
@@ -191,9 +192,9 @@ uint32_t cmp_compress_bound(uint32_t size);
  *			compress the data
  * @param src_size	size of a source data buffer in bytes
  *
- * @returns the minimum size needed for a compression working buffer (can be 0
- *	if no working buffer is needed) or an error, which can be checked using
- *	cmp_is_error()
+ * @returns the minimum size in bytes needed for a compression working buffer
+ *	(can be 0 if no working buffer is needed) or an error, which can be
+ *	checked using cmp_is_error()
  */
 
 uint32_t cmp_cal_work_buf_size(const struct cmp_params *params, uint32_t src_size);

--- a/lib/cmp.h
+++ b/lib/cmp.h
@@ -37,7 +37,7 @@
 
 /* ====== Version Information ====== */
 #define CMP_VERSION_MAJOR   0 /**< major part of the version ID */
-#define CMP_VERSION_MINOR   4 /**< minor part of the version ID */
+#define CMP_VERSION_MINOR   5 /**< minor part of the version ID */
 #define CMP_VERSION_RELEASE 0 /**< release part of the version ID */
 
 /**

--- a/lib/cmp.h
+++ b/lib/cmp.h
@@ -27,6 +27,8 @@
 
 #include <stdint.h>
 
+#include "cmp_header.h"
+
 /* ====== Utility Macros  ====== */
 /** Convert a token to a string literal */
 #define CMP_QUOTE(str)            #str
@@ -179,6 +181,35 @@ unsigned int cmp_is_error(uint32_t code);
  */
 
 uint32_t cmp_compress_bound(uint32_t size);
+
+
+/**
+ * @brief Calculate the maximum buffer size required for uncompressed storage
+ *
+ * This macro is useful for (statical) allocation of the compression destination
+ * buffer when using uncompressed storage.
+ * It calculates the worst-case size required for storing data in uncompressed
+ * format, including the compression header and optional checksum.
+ *
+ * It helps prevent compression failures due to insufficient destination buffer
+ * space in the following scenarios:
+ * - When using the CMP_ENCODER_UNCOMPRESSED encoder
+ * - When uncompressed_fallback_enabled is set
+ *
+ * In all other compression scenarios, use cmp_compress_bound(), which provides
+ * an upper bound assuming the worst-case compression ratio.
+ *
+ * @param src_size	the size of the data to compress, in bytes
+ *
+ * @returns the buffer size needed for uncompressed storage, or SIZE_MAX if
+ *	the source size is too large (exceeds CMP_HDR_MAX_COMPRESSED_SIZE
+ *	after accounting for header and checksum overhead)
+ */
+
+#define CMP_UNCOMPRESSED_BOUND(src_size)                                                  \
+	((src_size) <= (CMP_HDR_MAX_COMPRESSED_SIZE - CMP_HDR_SIZE - CMP_CHECKSUM_SIZE) ? \
+		 (CMP_HDR_SIZE + (src_size) + CMP_CHECKSUM_SIZE) :                        \
+		 SIZE_MAX)
 
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,7 @@ if use_debug
     '-Wformat-truncation',
     '-Wformat-security',
     '-Woverflow',
+    '-Wflex-array-member-not-at-end',
     '-Wdocumentation',
     '-Wmissing-declarations',
     '-Wmissing-prototypes',

--- a/programs/file.c
+++ b/programs/file.c
@@ -382,6 +382,14 @@ static int file_save(const char *filename, const void *buffer, size_t size)
 		SET_BINARY_MODE(stdout);
 	} else {
 		if (strcmp(filename, NULL_MARK)) {
+			struct stat st;
+
+			/* Check if destination is a directory */
+			if (stat(filename, &st) == 0 && S_ISDIR(st.st_mode)) {
+				LOG_ERROR("'%s' is a directory\n", filename);
+				return -1;
+			}
+
 			/* Check if destination file already exists */
 			fp = fopen(filename, "rb");
 			if (fp) {

--- a/test/cli_compression_test.py
+++ b/test/cli_compression_test.py
@@ -176,7 +176,7 @@ class TestCompression(unittest.TestCase):
         self.assertCli(
             result,
             returncode_exp=RETURN_FAILURE,
-            stderr_exp="already exists",
+            stderr_exp="is a directory",
             stderr_match_mode="contains",
         )
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -70,6 +70,7 @@ if ruby.found()
   gen_test_runner = subproject('unity').get_variable('gen_test_runner')
   test_lib = static_library('test_common_lib',
     files(['test_common.c']),
+    c_args : unit_testing_flags,
     dependencies : [unity_dep])
 
   unit_test_src = files([

--- a/test/test_initialisation.c
+++ b/test/test_initialisation.c
@@ -118,7 +118,7 @@ void test_detect_invalid_secondary_preprocessing_initialization(void)
 void test_ignore_invalid_secondary_preprocessing_when_not_used(void)
 {
 	const uint16_t src[2] = { 0x0001, 0x0203 };
-	DST_ALIGNED_U8 dst[CMP_HDR_SIZE + sizeof(src)];
+	DST_ALIGNED_U8 dst[CMP_UNCOMPRESSED_BOUND(sizeof(src))];
 	struct cmp_params par = { 0 };
 	struct cmp_context ctx;
 	uint32_t return_val, cmp_size;
@@ -174,7 +174,7 @@ void test_detect_invalid_secondary_endoder_initialisation(void)
 void test_ignore_invalid_secondary_encodder_when_not_used(void)
 {
 	const uint16_t src[2] = { 0x0001, 0x0203 };
-	DST_ALIGNED_U8 dst[CMP_HDR_SIZE + sizeof(src)];
+	DST_ALIGNED_U8 dst[CMP_UNCOMPRESSED_BOUND(sizeof(src))];
 	struct cmp_params par = { 0 };
 	struct cmp_context ctx;
 	uint32_t return_val, cmp_size;

--- a/test/test_preprocessing.c
+++ b/test/test_preprocessing.c
@@ -127,6 +127,14 @@ void test_iwt_transform_five(void)
 	check_iwt_transform(input, expected, sizeof(input));
 }
 
+void test_iwt_transform_seven(void)
+{
+	const int16_t input[]    = {  0,  0, 2,  0,  0, 0, 0 };
+	const int16_t expected[] = { -1, -1, 2, -1, -1, 0, 1 };
+
+	check_iwt_transform(input, expected, sizeof(input));
+}
+
 void test_iwt_transform_eight(void)
 {
 	const int16_t input[]    = { -3, 2, -1, 3, -2, 5, 0, 7 };


### PR DESCRIPTION
- Bump library version to 0.5, add CMP_UNCOMPRESSED_BOUND macro for buffer sizing
- Introduce Dockerfile and .dockerignore for containerized builds and testing
- Improve IWT preprocessing with better edge case handling
- Add directory existence check in file operations
- Enhance tests, build warnings, and documentation comments