### PR TITLE
perf(cmp): add fast path for uncompressed data writing

### DIFF
--- a/lib/cmp.h
+++ b/lib/cmp.h
@@ -38,7 +38,7 @@
 /* ====== Version Information ====== */
 #define CMP_VERSION_MAJOR   0 /**< major part of the version ID */
 #define CMP_VERSION_MINOR   7 /**< minor part of the version ID */
-#define CMP_VERSION_RELEASE 0 /**< release part of the version ID */
+#define CMP_VERSION_RELEASE 1 /**< release part of the version ID */
 
 /**
  * @brief Complete version number

--- a/lib/common/bitstream_writer.h
+++ b/lib/common/bitstream_writer.h
@@ -108,12 +108,12 @@ static __inline uint32_t bitstream_error(const struct bitstream_writer *bs)
  * @brief Adds up to 32 bits to the bitstream
  *
  * @note This function writes bits into an internal cache, which is only flushed to
- *       the output buffer when full or when bitstream_flush() is explicitly called.
- *       As a result, after completing a sequence of writes, the caller **must** call
- *       bitstream_flush() to ensure all bits are properly written to the buffer.
- * @note This function uses sticky error handling - once an error occurs, subsequent
- *       calls are ignored. Possible error conditions can be tested with
- *       bitstream_error() or bitstream_flush().
+ *	 the output buffer when full or when bitstream_flush() is explicitly called.
+ *	 As a result, after completing a sequence of writes, the caller **must** call
+ *	 bitstream_flush() to ensure all bits are properly written to the buffer.
+ * @note This function uses sticky error handling. Once an error occurs, subsequent
+ *	 calls are ignored. Possible error conditions can be tested with
+ *	 bitstream_error() or bitstream_flush().
  *
  * @param bs		pointer to an initialised bitstream_writer structure
  * @param value		bits to write to the bitstream; must be "clean", meaning

--- a/lib/common/bitstream_writer.h
+++ b/lib/common/bitstream_writer.h
@@ -27,6 +27,12 @@
 
 #define CMP_DST_ALIGNMENT sizeof(uint64_t)
 
+#if defined(__BIG_ENDIAN)
+#  define BITSTREAM_IS_CPU_BIG_ENDIAN 1
+#elif defined(__LITTLE_ENDIAN)
+#  define BITSTREAM_IS_CPU_BIG_ENDIAN 0
+#endif
+
 
 /**
  * @brief This structure maintains the state of the bitstream writer
@@ -87,6 +93,20 @@ static __inline void put_be64_aligned(void *ptr, uint64_t val)
 {
 	val = cpu_to_be64(val);
 	*(uint64_t *)ptr = val;
+}
+
+
+/**
+ * @brief Stores a 16-bit integer as big-endian bytes
+ *
+ * @param ptr	2 byte aligned address to write
+ * @param val	value to write
+ */
+
+static __inline void put_be16_aligned(void *ptr, uint16_t val)
+{
+	val = cpu_to_be16(val);
+	*(uint16_t *)ptr = val;
 }
 
 
@@ -154,6 +174,127 @@ static __inline void bitstream_add_bits32(struct bitstream_writer *bs, uint32_t 
 		bs->bit_cap += 64 - nb_bits;
 	} else {
 		bs->error = CMP_ERROR(DST_TOO_SMALL);
+	}
+}
+
+
+/**
+ * @brief Write an array of 16-bit values as big-endian to the bitstream
+ *
+ * @note The bitstream must be 63 bit aligned before calling. Call
+ *	 bitstream_flush() first if needed
+ * @note This function uses sticky error handling. Once an error occurs, subsequent
+ *	 calls are ignored. Possible error conditions can be tested with
+ *	 bitstream_error() or bitstream_flush().
+ *
+ * @param bs		pointer to initialized bitstream_writer
+ * @param src16		source buffer of 16-bit values (native endianness)
+ * @param nb_samples	number of samples to write
+ */
+
+static __inline void bitstream_add_be16_array(struct bitstream_writer *bs, const int16_t *src16,
+					      uint32_t nb_samples)
+{
+	uint32_t i;
+
+	if (cmp_is_error_int(bitstream_error(bs)))
+		return;
+
+	if (bs->bit_cap != 64) {
+		bs->error = CMP_ERROR(INT_BITSTREAM);
+		return;
+	}
+
+	if (!src16) {
+		bs->error = CMP_ERROR(INT_BITSTREAM);
+		return;
+	}
+
+	if (nb_samples > (size_t)(bs->end - bs->ptr) / sizeof(int16_t)) {
+		bs->error = CMP_ERROR(DST_TOO_SMALL);
+		return;
+	}
+
+	if (BITSTREAM_IS_CPU_BIG_ENDIAN) {
+		/* Fast path: no conversion needed on big-endian systems */
+		memcpy(bs->ptr, src16, nb_samples * sizeof(int16_t));
+	} else {
+		uint8_t *p = bs->ptr;
+
+		for (i = 0; i < nb_samples; i++) {
+			put_be16_aligned(p, (uint16_t)src16[i]);
+			p += sizeof(int16_t);
+		}
+	}
+
+	/* update the cache that a following bitstream_add_bits32() can work */
+	{
+		uint32_t aligned_samples = nb_samples & ~3U;
+		uint32_t remainder = nb_samples & 3U;
+
+		bs->ptr += aligned_samples * sizeof(int16_t);
+		for (i = 0; i < remainder; i++)
+			bitstream_add_bits32(bs, (uint16_t)src16[aligned_samples + i], 16);
+	}
+}
+
+
+/**
+ * @brief Write an array of 16-bit values (stored in 32-bit containers) as big-endian
+ *
+ * Extracts the lower 16 bits from each 32-bit value and writes them in big-endian
+ * byte order
+ *
+ * @note The bitstream must be 64 bit aligned before calling. Call
+ *	 bitstream_flush() first if needed
+ * @note This function uses sticky error handling. Once an error occurs, subsequent
+ *	 calls are ignored. Possible error conditions can be tested with
+ *	 bitstream_error() or bitstream_flush().
+ *
+ * @param bs		pointer to initialized bitstream_writer
+ * @param src16_in_32	source buffer of 32-bit values containing 16-bit samples
+ *			(native endianness)
+ * @param nb_samples	number of samples to write
+ */
+
+static __inline void bitstream_add_be16_in_32_array(struct bitstream_writer *bs,
+						    const int32_t *src16_in_32, uint32_t nb_samples)
+{
+	uint32_t i;
+	uint8_t *p;
+
+	if (cmp_is_error_int(bitstream_error(bs)))
+		return;
+
+	if (bs->bit_cap != 64) {
+		bs->error = CMP_ERROR(INT_BITSTREAM);
+		return;
+	}
+
+	if (!src16_in_32) {
+		bs->error = CMP_ERROR(INT_BITSTREAM);
+		return;
+	}
+
+	if (nb_samples > (size_t)(bs->end - bs->ptr) / sizeof(int16_t)) {
+		bs->error = CMP_ERROR(DST_TOO_SMALL);
+		return;
+	}
+
+	p = bs->ptr;
+	for (i = 0; i < nb_samples; i++) {
+		put_be16_aligned(p, (uint16_t)(src16_in_32[i]));
+		p += sizeof(uint16_t);
+	}
+
+	/* update the cache that a following bitstream_add_bits32() can work */
+	{
+		uint32_t aligned_samples = nb_samples & ~3U;
+		uint32_t remainder = nb_samples & 3U;
+
+		bs->ptr += aligned_samples * sizeof(int16_t);
+		for (i = 0; i < remainder; i++)
+			bitstream_add_bits32(bs, (uint16_t)src16_in_32[aligned_samples + i], 16);
 	}
 }
 

--- a/lib/common/cmp_header.c
+++ b/lib/common/cmp_header.c
@@ -133,7 +133,7 @@ uint32_t cmp_hdr_checksum_int(const struct sample_desc *desc)
 	 * Fast path: on big-endian systems with contiguous data, we can hash
 	 * directly without byte swapping.
 	 */
-	if (!XXH_CPU_LITTLE_ENDIAN && (desc->type == CMP_I16 || desc->type == CMP_U16))
+	if (!XXH_CPU_LITTLE_ENDIAN && (desc->dtype == CMP_I16 || desc->dtype == CMP_U16))
 		return XXH32(desc->data, desc->num_samples * sizeof(uint16_t), CHECKSUM_SEED);
 
 	/*

--- a/lib/common/sample_reader.h
+++ b/lib/common/sample_reader.h
@@ -11,7 +11,7 @@ struct sample_desc {
 	const void *data;
 	uint32_t num_samples;
 	uint8_t stride;
-	enum cmp_type type;
+	enum cmp_type dtype;
 };
 
 
@@ -44,7 +44,7 @@ static __inline uint32_t sample_read_src_init(struct sample_desc *src_desc, cons
 	src_desc->data = src;
 	src_desc->num_samples = src_size / stride;
 	src_desc->stride = stride;
-	src_desc->type = src_type;
+	src_desc->dtype = src_type;
 
 	return CMP_ERROR(NO_ERROR);
 }

--- a/lib/compress/cmp.c
+++ b/lib/compress/cmp.c
@@ -258,7 +258,7 @@ static uint32_t compress_engine(struct cmp_context *ctx, void *dst, uint32_t dst
 	hdr.sequence_number = ctx->sequence_number;
 	hdr.preprocessing = selected_preprocessing;
 	hdr.encoder_type = selected_encoder_type;
-	hdr.original_dtype = src_desc->type;
+	hdr.original_dtype = src_desc->dtype;
 	if (selected_preprocessing == CMP_PREPROCESS_MODEL)
 		hdr.preprocess_param = ctx->params.model_rate;
 	else
@@ -297,7 +297,7 @@ static uint32_t compress_engine(struct cmp_context *ctx, void *dst, uint32_t dst
 			else
 				model[i] = update_model(sample_read_i16(src_desc, i), model[i],
 							(int)ctx->params.model_rate,
-							src_desc->type);
+							src_desc->dtype);
 		}
 	}
 

--- a/lib/compress/cmp.c
+++ b/lib/compress/cmp.c
@@ -194,6 +194,30 @@ uint32_t cmp_initialise(struct cmp_context *ctx, const struct cmp_params *params
 }
 
 
+/* fast shortcut for uncompressed data; assume model has sufficient size*/
+static void write_uncompressed(struct bitstream_writer *bs, const struct sample_desc *src_desc,
+			       int16_t *model)
+{
+	switch (src_desc->dtype) {
+	case CMP_I16:
+	case CMP_U16:
+		bitstream_add_be16_array(bs, src_desc->data, src_desc->num_samples);
+		if (model)
+			memcpy(model, src_desc->data, get_packed_size(src_desc));
+		break;
+	case CMP_I16_IN_I32:
+		bitstream_add_be16_in_32_array(bs, src_desc->data, src_desc->num_samples);
+		if (model) {
+			uint32_t i;
+
+			for (i = 0; i < src_desc->num_samples; i++)
+				model[i] = sample_read_i16(src_desc, i);
+		}
+		break;
+	}
+}
+
+
 /* Main compression loop */
 static uint32_t compress_engine(struct cmp_context *ctx, void *dst, uint32_t dst_capacity,
 				const struct sample_desc *src_desc)
@@ -271,33 +295,39 @@ static uint32_t compress_engine(struct cmp_context *ctx, void *dst, uint32_t dst
 	if (cmp_is_error_int(ret))
 		return ret;
 
-	compress_bound = cmp_compress_bound(get_packed_size(src_desc));
-	if (cmp_is_error_int(compress_bound))
-		compress_bound = ~0U;
+	if (selected_preprocessing == CMP_PREPROCESS_NONE &&
+	    selected_encoder_type == CMP_ENCODER_UNCOMPRESSED) {
+		write_uncompressed(&bs, src_desc, model);
+	} else {
+		compress_bound = cmp_compress_bound(get_packed_size(src_desc));
+		if (cmp_is_error_int(compress_bound))
+			compress_bound = ~0U;
 
-	preprocess = preprocessing_get_method(selected_preprocessing);
-	if (preprocess == NULL)
-		return CMP_ERROR(PARAMS_INVALID);
+		preprocess = preprocessing_get_method(selected_preprocessing);
+		if (preprocess == NULL)
+			return CMP_ERROR(PARAMS_INVALID);
 
-	n_values = preprocess->init(src_desc, ctx->work_buf, ctx->work_buf_size);
-	if (cmp_is_error_int(n_values))
-		return n_values;
+		n_values = preprocess->init(src_desc, ctx->work_buf, ctx->work_buf_size);
+		if (cmp_is_error_int(n_values))
+			return n_values;
 
-	for (i = 0; i < n_values; i++) {
-		int16_t const value = preprocess->process(i, src_desc, ctx->work_buf);
+		for (i = 0; i < n_values; i++) {
+			int16_t const value = preprocess->process(i, src_desc, ctx->work_buf);
 
-		cmp_encoder_encode_s16(&enc, value, &bs);
-		if (dst_capacity < compress_bound)
-			if (cmp_is_error_int(bitstream_error(&bs)))
-				break;
+			cmp_encoder_encode_s16(&enc, value, &bs);
+			if (dst_capacity < compress_bound)
+				if (cmp_is_error_int(bitstream_error(&bs)))
+					break;
 
-		if (model) {
-			if (ctx->sequence_number == 0)
-				model[i] = sample_read_i16(src_desc, i);
-			else
-				model[i] = update_model(sample_read_i16(src_desc, i), model[i],
-							(int)ctx->params.model_rate,
-							src_desc->dtype);
+			if (model) {
+				if (ctx->sequence_number == 0)
+					model[i] = sample_read_i16(src_desc, i);
+				else
+					model[i] = update_model(sample_read_i16(src_desc, i),
+								model[i],
+								(int)ctx->params.model_rate,
+								src_desc->dtype);
+			}
 		}
 	}
 

--- a/lib/compress/preprocess.c
+++ b/lib/compress/preprocess.c
@@ -198,7 +198,7 @@ static void iwt_multi_level_decomposition_i16(const struct sample_desc *src_desc
 		return;
 	}
 
-	if (src_desc->type == CMP_I16_IN_I32) {
+	if (src_desc->dtype == CMP_I16_IN_I32) {
 		uint32_t i;
 		/*
 		 * For non-contiguous 16-bit samples stored in 32-bit words,

--- a/test/test_encoder.c
+++ b/test/test_encoder.c
@@ -103,6 +103,58 @@ void test_detect_bitstream_overflow(void)
 }
 
 
+void test_bitstream_write_bytes_than_bits(void)
+{
+	uint32_t size;
+	struct bitstream_writer bsw;
+	uint8_t expected_bs[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+				  0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D };
+	DST_ALIGNED_U8 buffer[sizeof(expected_bs)];
+	int16_t src16[3] = { 0x0001, 0x0203, 0x0405 };
+
+	memset(buffer, 0xFF, sizeof(buffer));
+
+	TEST_ASSERT_CMP_SUCCESS(bitstream_writer_init(&bsw, buffer, sizeof(buffer)));
+
+	bitstream_add_be16_array(&bsw, src16, ARRAY_SIZE(src16));
+	bitstream_add_bits32(&bsw, 0x0607, 16);
+	bitstream_add_bits32(&bsw, 0x08, 8);
+	bitstream_add_bits32(&bsw, 0x09, 8);
+	bitstream_add_bits32(&bsw, 0x0A0B0C0D, 32);
+	size = bitstream_flush(&bsw);
+
+	TEST_ASSERT_CMP_SUCCESS(size);
+	TEST_ASSERT_EQUAL(sizeof(expected_bs), size);
+	TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_bs, buffer, sizeof(expected_bs));
+}
+
+
+void test_bitstream_write_16in32_array_than_bits(void)
+{
+	uint32_t size;
+	struct bitstream_writer bsw;
+	uint8_t expected_bs[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+				  0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D };
+	DST_ALIGNED_U8 buffer[sizeof(expected_bs)];
+	int32_t src32[3] = { 0x7FFF0001, 0x7FFF0203, 0x7FFF0405 };
+
+	memset(buffer, 0xFF, sizeof(buffer));
+
+	TEST_ASSERT_CMP_SUCCESS(bitstream_writer_init(&bsw, buffer, sizeof(buffer)));
+
+	bitstream_add_be16_in_32_array(&bsw, src32, ARRAY_SIZE(src32));
+	bitstream_add_bits32(&bsw, 0x0607, 16);
+	bitstream_add_bits32(&bsw, 0x08, 8);
+	bitstream_add_bits32(&bsw, 0x09, 8);
+	bitstream_add_bits32(&bsw, 0x0A0B0C0D, 32);
+	size = bitstream_flush(&bsw);
+
+	TEST_ASSERT_CMP_SUCCESS(size);
+	TEST_ASSERT_EQUAL(sizeof(expected_bs), size);
+	TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_bs, buffer, sizeof(expected_bs));
+}
+
+
 static void run_encoder_test(enum cmp_encoder_type type, uint32_t encoder_param,
 			     uint32_t encoder_outlier, const int16_t *input_data,
 			     uint32_t input_size, const uint8_t *expected, uint32_t expected_size,


### PR DESCRIPTION
Add bitstream_add_be16_array() and bitstream_add_be16_in_32_array()
helpers that write 16-bit samples as big-endian bytes, bypassing the
bit-packing cache.